### PR TITLE
ISSUE-35: members data is taken from external file. …

### DIFF
--- a/Dialogs/membersMenu.sqf
+++ b/Dialogs/membersMenu.sqf
@@ -2,10 +2,10 @@ createDialog "members_menu";
 
 waitUntil {dialog};
 waitUntil {!dialog};
-if (isNil"miembros") then
+if (isNil"membersPool") then
 	{
-	miembros = [];
-	publicVariable "miembros";
+	membersPool = [];
+	publicVariable "membersPool";
 	hint "Server Membership Disabled.\n\nAnyone can use the HQ Ammobox and become Commander (if Switch Commander is enabled).\n\nIf you load a session with this feature enabled, it will become enabled.\n\nUse this option for Private Server environments.";
 	[] execVM "Dialogs\firstLoad.sqf";
 	};

--- a/Save/fn_loadGame.sqf
+++ b/Save/fn_loadGame.sqf
@@ -6,7 +6,7 @@ petros allowdamage false;
 
 //preinit
 ["campaign_playerList"] call fn_loadData;
-["miembros"] call fn_loadData; publicVariable "miembros";
+["membersPool"] call fn_loadData; publicVariable "membersPool";
 flag_playerList = true;
 publicVariable "flag_playerList";
 

--- a/Save/fn_saveFunctions.sqf
+++ b/Save/fn_saveFunctions.sqf
@@ -162,7 +162,7 @@ fn_saveProfile = {
 
 //ADD VARIABLES TO THIS ARRAY THAT NEED SPECIAL SCRIPTING TO LOAD
 specialVarLoads =
-["campaign_playerList","cuentaCA","miembros","antenas","posHQ","prestigeNATO","prestigeCSAT","APCAAFcurrent","tanksAAFcurrent","planesAAFcurrent","helisAAFcurrent","time","resourcesAAF","skillFIA","skillAAF","destroyedBuildings","flag_chopForest","BE_data","enableOldFT","enableMemAcc","hr","resourcesFIA","vehicles","weapons","magazines","items","backpacks","objectsHQ","addObjectsHQ","supportOPFOR","supportBLUFOR","garrison","mines","emplacements","campList","tasks","idleBases","unlockedWeapons","unlockedItems","unlockedMagazines","unlockedBackpacks"];
+["campaign_playerList","cuentaCA","membersPool","antenas","posHQ","prestigeNATO","prestigeCSAT","APCAAFcurrent","tanksAAFcurrent","planesAAFcurrent","helisAAFcurrent","time","resourcesAAF","skillFIA","skillAAF","destroyedBuildings","flag_chopForest","BE_data","enableOldFT","enableMemAcc","hr","resourcesFIA","vehicles","weapons","magazines","items","backpacks","objectsHQ","addObjectsHQ","supportOPFOR","supportBLUFOR","garrison","mines","emplacements","campList","tasks","idleBases","unlockedWeapons","unlockedItems","unlockedMagazines","unlockedBackpacks"];
 
 /*
 	Variables that are loaded, but do not require special procedures
@@ -175,6 +175,7 @@ fn_setData = {
 
 	if (_varName in specialVarLoads) then {
 		call {
+		    if(_varName == 'membersPool') exitWith {{membersPool pushBackUnique _x;} forEach _varValue;};
 			if(_varName == 'campaign_playerList') exitWith {server setVariable ["campaign_playerList",_varValue,true]};
 			if(_varName == 'cuentaCA') exitWith {cuentaCA = _varValue max 2700};
 			if(_varName == 'flag_chopForest') then {

--- a/Save/fn_saveGame.sqf
+++ b/Save/fn_saveGame.sqf
@@ -10,7 +10,7 @@ flag_savingServer = true;
 //game
 ["cuentaCA", cuentaCA] call fn_saveData;
 ["smallCAmrk", smallCAmrk] call fn_saveData;
-["miembros", miembros] call fn_saveData;
+["membersPool", membersPool] call fn_saveData;
 ["antenas", antenasmuertas] call fn_saveData;
 ["mrkAAF", mrkAAF - controles] call fn_saveData;
 ["mrkFIA", mrkFIA - puestosFIA - controles] call fn_saveData;

--- a/UI/startGame.sqf
+++ b/UI/startGame.sqf
@@ -7,7 +7,7 @@ _display displayRemoveEventHandler ["KeyDown", A3AS_menu_escEH];
 
 if (_restart) exitWith {
 	switchCom = false; publicVariable 'switchCom';
-	{miembros pushBack (getPlayerUID _x)} forEach playableUnits; publicVariable 'miembros';
+	{membersPool pushBack (getPlayerUID _x)} forEach playableUnits; publicVariable 'membersPool';
 	closedialog 100;
 
 	if ((isNil 'statsLoaded') && (isNil 'placementDone')) then {
@@ -20,8 +20,8 @@ call {
 		switchCom = true; publicVariable 'switchCom';
 	};
 	if !(ctrlChecked (_display displayCtrl 2501)) then {
-		{miembros pushBack (getPlayerUID _x)} forEach playableUnits;
-		publicVariable 'miembros';
+		{membersPool pushBack (getPlayerUID _x)} forEach playableUnits;
+		publicVariable 'membersPool';
 	};
 	if !(ctrlChecked (_display displayCtrl 2502)) exitWith {
 		//disableUserInput true;

--- a/dialogs.hpp
+++ b/dialogs.hpp
@@ -400,10 +400,10 @@ class members_menu
 		AS_BOX_D(BOX_H_4);
 		AS_FRAME_D(FRAME_H_4, "Enable Server Membership?");
 
-		BTN_L1(-1, "YES", "", "miembros = []; {miembros pushBack (getPlayerUID _x)} forEach playableUnits; publicVariable ""miembros""; hint ""Server Membership Enabled.\n\nAll the present players have been added to the Member's List.\n\nNon-members cannot use the HQ Ammobox and cannot be commanders, even with Switch Commander enabled.\n\nIf you load a session with this feature disabled, it will change to disabled.\n\nUse this option for Open Server Environments"";");
-		BTN_R1(-1, "NO", "", "miembros = []; publicVariable ""miembros""; hint ""Server Membership Disabled.\n\nAnyone can use the HQ Ammobox and become Commander (if Switch Commander is enabled).\n\nIf you load a session with this feature enabled, it will become enabled.\n\nUse this option for Private Server environments."";");
+		BTN_L1(-1, "YES", "", "membersPool = []; {membersPool pushBack (getPlayerUID _x)} forEach playableUnits; publicVariable ""membersPool""; hint ""Server Membership Enabled.\n\nAll the present players have been added to the Member's List.\n\nNon-members cannot use the HQ Ammobox and cannot be commanders, even with Switch Commander enabled.\n\nIf you load a session with this feature disabled, it will change to disabled.\n\nUse this option for Open Server Environments"";");
+		BTN_R1(-1, "NO", "", "membersPool = []; publicVariable ""membersPool""; hint ""Server Membership Disabled.\n\nAnyone can use the HQ Ammobox and become Commander (if Switch Commander is enabled).\n\nIf you load a session with this feature enabled, it will become enabled.\n\nUse this option for Private Server environments."";");
 
-		BTN_M(BTN_Y_2, -1, "Done", "", "if (!isNil ""miembros"") then {closedialog 0; [] execVM ""Dialogs\firstLoad.sqf"";} else {hint ""Select an option first""};");
+		BTN_M(BTN_Y_2, -1, "Done", "", "if (!isNil ""membersPool"") then {closedialog 0; [] execVM ""Dialogs\firstLoad.sqf"";} else {hint ""Select an option first""};");
 
 	};
 };
@@ -731,9 +731,9 @@ class misCiv_menu // 400
 	AS_FRAME_D(FRAME_H_4, "Available Missions");
 	BTN_BACK(A_CLOSE);
 
-	#define STR_CIV_ASS "closeDialog 0; if (((getPlayerUID player) in miembros) || (player == Slowhand)) then {[[""ASS""],""misReqCiv""] call BIS_fnc_MP} else {hint ""Stranger does not trust you.""};"
-	#define STR_CIV_CVY "closeDialog 0; if (((getPlayerUID player) in miembros) || (player == Slowhand)) then {[[""CONVOY""],""misReqCiv""] call BIS_fnc_MP} else {hint ""Stranger does not trust you.""};"
-	#define STR_CIV_CON "closeDialog 0; if (((getPlayerUID player) in miembros) || (player == Slowhand)) then {[[""CON""],""misReqCiv""] call BIS_fnc_MP} else {hint ""Stranger does not trust you.""};"
+	#define STR_CIV_ASS "closeDialog 0; if (((getPlayerUID player) in membersPool) || (player == Slowhand)) then {[[""ASS""],""misReqCiv""] call BIS_fnc_MP} else {hint ""Stranger does not trust you.""};"
+	#define STR_CIV_CVY "closeDialog 0; if (((getPlayerUID player) in membersPool) || (player == Slowhand)) then {[[""CONVOY""],""misReqCiv""] call BIS_fnc_MP} else {hint ""Stranger does not trust you.""};"
+	#define STR_CIV_CON "closeDialog 0; if (((getPlayerUID player) in membersPool) || (player == Slowhand)) then {[[""CON""],""misReqCiv""] call BIS_fnc_MP} else {hint ""Stranger does not trust you.""};"
 
 	BTN_L1(-1, "Assassination Mission", "", STR_CIV_ASS);
 	BTN_R1(-1, "Convoy Ambush", "", STR_CIV_CVY);
@@ -755,10 +755,10 @@ class misMil_menu // 410
 	AS_FRAME_D(FRAME_H_4, "Available Missions");
 	BTN_BACK(A_CLOSE);
 
-	#define STR_MIL_ASS "closeDialog 0; if (((getPlayerUID player) in miembros) || (player == Slowhand)) then {[[""AS""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
-	#define STR_MIL_CVY "closeDialog 0; if (((getPlayerUID player) in miembros) || (player == Slowhand)) then {[[""CONVOY""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
-	#define STR_MIL_CON "closeDialog 0; if (((getPlayerUID player) in miembros) || (player == Slowhand)) then {[[""CON""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
-	#define STR_MIL_DES "closeDialog 0; if (((getPlayerUID player) in miembros) || (player == Slowhand)) then {[[""DES""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
+	#define STR_MIL_ASS "closeDialog 0; if (((getPlayerUID player) in membersPool) || (player == Slowhand)) then {[[""AS""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
+	#define STR_MIL_CVY "closeDialog 0; if (((getPlayerUID player) in membersPool) || (player == Slowhand)) then {[[""CONVOY""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
+	#define STR_MIL_CON "closeDialog 0; if (((getPlayerUID player) in membersPool) || (player == Slowhand)) then {[[""CON""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
+	#define STR_MIL_DES "closeDialog 0; if (((getPlayerUID player) in membersPool) || (player == Slowhand)) then {[[""DES""],""misReqMil""] call BIS_fnc_MP} else {hint ""Nomad does not trust you.""};"
 
 	BTN_L1(-1, "Assassination Mission", "", STR_MIL_ASS);
 	BTN_L2(-1, "Convoy Ambush", "", STR_MIL_CVY);

--- a/init.sqf
+++ b/init.sqf
@@ -59,22 +59,17 @@ if(isServer) then {
     AS_session_server = _campaignID; publicVariable "AS_session_server";
 
     switchCom = false; publicVariable "switchCom";
-    miembros = []; publicVariable "miembros";
+    membersPool = []; publicVariable "membersPool";
 
     waitUntil {!isNil "serverID"};
-    //enableRestart = [true, false] select (("AS_enableCampaignReset" call BIS_fnc_getParamValue) == 0);
-    //publicVariable "enableRestart";
+    //Loading members list anyway
+    //Loading membersPool from ext file
+    [] call compile preprocessFileLineNumbers "orgPlayers\mList.sqf";
+    //loading membersPool from profileNameSpace
+    ["membersPool"] call fn_loadData;
+
     if (serverName in servidoresOficiales) then {
         //[] execVM "orgPlayers\mList.sqf";
-        [] call compile preprocessFileLineNumbers "orgPlayers\mList.sqf"; //Need to use this here, otherwise we get an empty miembros list by the time it is being checked further in this file. This would make some non-member a commander WITHOUT loading the campaign. Sparker.
-        ["miembros"] call fn_loadData;
-
-        //Output the member list
-        diag_log "init.sqf: member list:";
-        {
-            diag_log format ["init.sqf: %1", _x];
-        } forEach miembros;
-
         {
             if (([_x] call isMember) AND (isNull Slowhand)) then {
                 Slowhand = _x;

--- a/initPlayerLocal.sqf
+++ b/initPlayerLocal.sqf
@@ -120,8 +120,8 @@ if (_isJip) then {
 	[true] execVM "reinitY.sqf";
 	if !([player] call isMember) then {
 		if (serverCommandAvailable "#logout") then {
-			miembros pushBack (getPlayerUID player);
-			publicVariable "miembros";
+			membersPool pushBack (getPlayerUID player);
+			publicVariable "membersPool";
 			hint localize "STR_HINTS_INIT_ADMIN_MEMBER"
 		} else {
 			hint format [localize "STR_HINTS_INIT_GUEST_WELCOME", name player];
@@ -130,7 +130,7 @@ if (_isJip) then {
 		hint format [localize "STR_HINTS_INIT_MEMBER_RETURN", name player];
 
 		if (serverName in servidoresOficiales) then {
-			if ((count playableUnits == maxPlayers) AND (({[_x] call isMember} count playableUnits) < count miembros)) then {
+			if ((count playableUnits == maxPlayers) AND (({[_x] call isMember} count playableUnits) < count membersPool)) then {
 				{
 					if !([_x] call isMember) exitWith {
 						["serverFull",false,1,false,false] remoteExec ["BIS_fnc_endMission",_x];
@@ -203,7 +203,7 @@ if (_isJip) then {
 				//};
 				diag_log "Antistasi MP Client. Client finished";
 		    } else {
-		    	miembros = [];
+		    	membersPool = [];
 		    	[] execVM "Dialogs\firstLoad.sqf";
 		    };
 		};

--- a/initServer.sqf
+++ b/initServer.sqf
@@ -10,6 +10,7 @@ call compile preprocessFileLineNumbers "initZones.sqf";
 diag_log "Antistasi MP Server. Zones init finished";
 initZones = true; publicVariable "initZones";
  call compile preprocessFileLineNumbers "initPetros.sqf";
+ diag_log "Antistasi MP Server. Petros init finished";
 
 //Sparker's WarStatistics and roadblock spawning script. Remove these lines if you don't need it:
 //(from here)//
@@ -18,6 +19,7 @@ call compile preprocessFileLineNumbers "WarStatistics\initFunctions.sqf";
 call compile preprocessFileLineNumbers "WarStatistics\initVariablesServer.sqf";
 //call compile preprocessFileLineNumbers "WarStatistics\initRoadblocks2.sqf";
 ws_grid = call ws_fnc_newGridArray;
+diag_log "Antistasi MP Server. WarStatistics init finished";
 //(up to here)//
 
 ["Initialize"] call BIS_fnc_dynamicGroups; //Exec on Server

--- a/initVar.sqf
+++ b/initVar.sqf
@@ -223,7 +223,7 @@ publicVariable "unlockedItems";
 publicVariable "unlockedOptics";
 publicVariable "unlockedBackpacks";
 publicVariable "unlockedMagazines";
-publicVariable "miembros";
+publicVariable "membersPool";
 publicVariable "vehInGarage";
 publicVariable "reportedVehs";
 publicVariable "activeACE";

--- a/mission.sqm
+++ b/mission.sqm
@@ -124,7 +124,7 @@ class Mission
 {
 	class Intel
 	{
-		briefingName="[SP/CO] - Antistasi Altis Blufor 1.7.17 ";
+		briefingName="[SP/CO] - Antistasi Altis Blufor 1.7.17";
 		overviewText="Build FIA Army from scratch and defeat the AAF and CSAT forces in a whole map Dynamic Mission.";
 		resistanceWest=0;
 		resistanceEast=1;

--- a/onPlayerDisconnect.sqf
+++ b/onPlayerDisconnect.sqf
@@ -55,7 +55,7 @@ if (_player isEqualTo Slowhand) then{
 		};
 	} forEach allGroups;
 
-	if (((count playableUnits > 0) and (count miembros == 0)) or ({(getPlayerUID _x) in miembros} count playableUnits > 0)) then{
+	if (((count playableUnits > 0) and (count membersPool == 0)) or ({(getPlayerUID _x) in membersPool} count playableUnits > 0)) then{
 		[] spawn assignStavros;
 	};
 

--- a/orgPlayers/isMember.sqf
+++ b/orgPlayers/isMember.sqf
@@ -3,6 +3,6 @@ private ["_check","_player"];
 
 _check = false;
 _player = _unit getVariable ["owner",_unit];
-if ((count miembros == 0) OR ((getPlayerUID _player) in miembros) OR (!isMultiplayer)) then {_check = true};
+if ((count membersPool == 0) OR ((getPlayerUID _player) in membersPool) OR (!isMultiplayer)) then {_check = true};
 
 _check

--- a/orgPlayers/mList.sqf
+++ b/orgPlayers/mList.sqf
@@ -1,7 +1,9 @@
 if !(isServer) exitWith {};
-
+//This is the path to external storage folder(folder should be in the root of arma3 folder).
+externalConfigFolder = "\A3Antistasi";
 private ["_mList"];
 
+//TODO remove this after external loading is tested
 _mList = [
 	"76561197960604947",  	//Fenris
 	"76561197961960492",  	//ForeingInvestor
@@ -57,7 +59,19 @@ _mList = [
 	"76561198057119793"		// Duke
 ];
 
+diag_log format ["isFilePatchingEnabled: %1", isFilePatchingEnabled];
+if(isFilePatchingEnabled) then {
+    _memberList = loadFile (externalConfigFolder + "\memberlist.txt");
+    if ( _memberList != "" ) then
+	{
+	    //Members list is in form of CRLF separated playerIds
+	    _mList = _memberList splitString toString [13,10];
+	    diag_log format ["DEBUG: External content from %1",externalConfigFolder + "\memberlist.txt"];
+	    {diag_log format ["DEBUG: members list> %1", _x];} forEach _mList;
+	};
+};
+
 {
-	miembros pushBackUnique _x;
+	membersPool pushBackUnique _x;
 } forEach _mList;
-publicVariable "miembros";
+publicVariable "membersPool";

--- a/orgPlayers/memberAdd.sqf
+++ b/orgPlayers/memberAdd.sqf
@@ -2,24 +2,24 @@ params [["_action","add"]];
 private ["_target","_uid"];
 
 if (!(serverCommandAvailable "#logout") AND !isServer) exitWith {hint localize "STR_HINTS_GEN_RESTRICTED_ADMIN"};
-if (count miembros == 0) exitWith {hint localize "STR_HINTS_GEN_MEM_DIS"};
+if (count membersPool == 0) exitWith {hint localize "STR_HINTS_GEN_MEM_DIS"};
 
 _target = cursortarget;
 
 if (!isPlayer _target) exitWith {hint localize "STR_HINTS_GEN_MEM_TARGET"};
 _uid = getPlayerUID _target;
-if ((_action == "add") AND (_uid in miembros)) exitWith {hint localize "STR_HINTS_GEN_MEM_ADD_FAIL"};
-if ((_action == "remove") AND !(_uid in miembros)) exitWith {hint localize "STR_HINTS_GEN_MEM_REM_FAIL"};
+if ((_action == "add") AND (_uid in membersPool)) exitWith {hint localize "STR_HINTS_GEN_MEM_ADD_FAIL"};
+if ((_action == "remove") AND !(_uid in membersPool)) exitWith {hint localize "STR_HINTS_GEN_MEM_REM_FAIL"};
 
 if (_action == "add") then {
-	miembros pushBackUnique _uid;
+	membersPool pushBackUnique _uid;
 	hint format [localize "STR_HINTS_GEN_MEM_ADD_SUC",name _target];
 } else {
-	miembros = miembros - [_uid];
+	membersPool = membersPool - [_uid];
 	hint format [localize "STR_HINTS_GEN_MEM_REM_SUC",name _target];
 };
 
-publicVariable "miembros";
+publicVariable "membersPool";
 
 //Stef making a code to give yourself membership
-//miembros pushBackUnique getPlayerUID player
+//membersPool pushBackUnique getPlayerUID player

--- a/orgPlayers/membersList.sqf
+++ b/orgPlayers/membersList.sqf
@@ -1,6 +1,6 @@
 private ["_text","_counter","_player"];
 
-if (count miembros == 0) exitWith {hint localize "STR_HINTS_GEN_MEM_DIS"};
+if (count membersPool == 0) exitWith {hint localize "STR_HINTS_GEN_MEM_DIS"};
 
 _text = "Ingame Members\n\n";
 _counter = 0;
@@ -8,7 +8,7 @@ _counter = 0;
 	_player = _x getVariable ["owner",objNull];
 	if (!isNull _player) then {
 		_uid = getPlayerUID _player;
-		if (_uid in miembros) then {_text = format ["%1%2\n",_text,name _player]} else {_counter = _counter + 1};
+		if (_uid in membersPool) then {_text = format ["%1%2\n",_text,name _player]} else {_counter = _counter + 1};
 	};
 } forEach playableUnits;
 


### PR DESCRIPTION
Members are also saved/loaded through ProfileNamespace. All references to "miembros" are renamed to "membersPool" (spanish-endlish maintanance)
Fixes #35 

To enable external file loading, server should start with `-filePatching` parameter
External content is loaded from `%ARMA3_ROOT%\A3Antistasi\memberlist.txt`
**memberlist.txt** (contains playerIds of members, every entry on its own line)
```
111111111
222222222
333333333
```

Example of my server configuration
**arma3server.cmd**
```
SET A3ServerBin=%A3BasePath%\A3Master

SET A3ServerProfiles=c:\Server_Antistasi\Profiles
SET A3ServerPar=c:\Server_Antistasi\server_parameters.txt
SET A3ServerCfg=c:\Server_Antistasi\basic.cfg
SET A3ServerConfig=c:\Server_Antistasi\config_server.config
SET A3BattlEye=c:\Server_Antistasi\BattlEye

start "A3Server" /normal "%A3ServerBin%\arma3server_x64.exe" "-par=%A3ServerPar%" "-profiles=%A3ServerProfiles%" "-cfg=%A3ServerCfg%" "-config=%A3ServerConfig%"
```
**server_parameters.txt**
```
-nosplash
-skipIntro
-world=none
-name=Antistasi
-autoInit
-filePatching
-serverMod=d:\Games\SteamLibrary\SteamApps\common\Arma 3\!Workshop\@ace;d:\Games\SteamLibrary\SteamApps\common\Arma 3\!Workshop\@CBA_A3;d:\Games\SteamLibrary\SteamApps\common\Arma 3\!Workshop\@RHSAFRF;d:\Games\SteamLibrary\SteamApps\common\Arma 3\!Workshop\@RHSGREF;d:\Games\SteamLibrary\SteamApps\common\Arma 3\!Workshop\@RHSUSAF;d:\Games\SteamLibrary\SteamApps\common\Arma 3\!Workshop\@XLA_FixedArsenal
```
**basic.cfg** (actually whatever options)
```
language="English";
adapter=-1;
MinBandwidth=800000;
MaxBandwidth=25000000;
MaxMsgSend=384;
MaxSizeGuaranteed=512;
MaxSizeNonguaranteed=256;
MinErrorToSend=0.003;
MaxCustomFileSize=100000;
Windowed=0;
serverLongitude=0;
serverLatitude=52;
serverLongitudeAuto=0;
serverLatitudeAuto=52;
```
**config_server.config**
```
//
// server.cfg
//
// comments are written with "//" in front of them.

// NOTE: More parameters and details are available at http://community.bistudio.com/wiki/server.cfg

// STEAM PORTS (not needed anymore, it's +1 +2 to gameport)
// steamPort       = 8766;     // default 8766, needs to be unique if multiple serves on same box
// steamQueryPort  = 27016;    // default 27016, needs to be unique if multiple servers on same box

// GENERAL SETTINGS
hostname       = "IrLED dev stage server";    // Name of the server displayed in the public server list
password     = "password";      // Password required to join the server (remove // at start of line to enable)
passwordAdmin  = "adminpassword";       // Password to login as admin. Open the chat and type: #login password
maxPlayers     = 40;    // Maximum amount of players, including headless clients. Anybody who joins the server is considered a player, regardless of their role or team.
persistent     = 1;     // If set to 1, missions will continue to run after all players have disconnected; required if you want to use the -autoInit startup parameter

// VOICE CHAT
disableVoN       = 0;     // If set to 1, voice chat will be disabled
vonCodecQuality  = 10;    // Supports range 1-30; 1-10 is 8kHz (narrowband), 11-20 is 16kHz (wideband), 21-30 is 32kHz (ultrawideband); higher = better sound quality, more bandwidth consumption

// VOTING
voteMissionPlayers  = 1;       // Minimum number of players required before displaying the mission selection screen, if you have not already selected a mission in this config
voteThreshold       = 0.33;    // Percentage (0.00 to 1.00) of players needed to vote something into effect, for example an admin or a new mission. Set to 9999 to disable voting.
allowedVoteCmds[] =            // Voting commands allowed to players
{
	// {command, preinit, postinit, threshold} - specifying a threshold value will override "voteThreshold" for that command
	//{"admin", false, false}, // vote admin
	//{"kick", false, true, 0.51}, // vote kick
	//{"missions", false, false}, // mission change
	//{"mission", false, false}, // mission selection
	//{"restart", false, false}, // mission restart
	//{"reassign", false, false} // mission restart with roles unassigned
};

// WELCOME MESSAGE ("message of the day")
// It can be several lines, separated by comma
// Empty messages "" will not be displayed, but can be used to increase the delay before other messages
motd[] =
{
	"Welcome to My Arma 3 Server",
	"Teamspeak: ts.somewhere.com",
	"Website: www.example.com"
};
motdInterval = 5;    // Number of seconds between each message

// MISSIONS CYCLE
class Missions
{
	class Mission1
	{
		template = "Antistasi_dev.Altis"; // Filename of pbo in MPMissions folder
		difficulty = "Custom"; // "Recruit", "Regular", "Veteran", "Custom"
	};
};

// LOGGING
timeStampFormat  = "short";                 // Timestamp format used in the server RPT logs. Possible values are "none" (default), "short", "full"
logFile          = "server_console.log";    // Server console output filename

// SECURITY
BattlEye             = 0;    // If set to 1, BattlEye Anti-Cheat will be enabled on the server (default: 1, recommended: 1)
verifySignatures     = 0;    // If set to 2, players with unknown or unsigned mods won't be allowed join (default: 0, recommended: 2)
kickDuplicate        = 1;    // If set to 1, players with an ID that is identical to another player will be kicked (recommended: 1)
allowedFilePatching  = 0;    // Prevents clients with filePatching enabled from joining the server (0 = block filePatching, 1 = allow headless clients, 2 = allow all) (default: 0, recommended: 1)

// FILE EXTENSIONS
allowedLoadFileExtensions[] =       {"hpp","sqs","sqf","fsm","cpp","paa","txt","xml","inc","ext","sqm","ods","fxy","lip","csv","kb","bik","bikb","html","htm","biedi"}; // only allow files with those extensions to be loaded via loadFile command (since Arma 3 v1.19.124216) 
allowedPreprocessFileExtensions[] = {"hpp","sqs","sqf","fsm","cpp","paa","txt","xml","inc","ext","sqm","ods","fxy","lip","csv","kb","bik","bikb","html","htm","biedi"}; // only allow files with those extensions to be loaded via preprocessFile / preprocessFileLineNumbers commands (since Arma 3 v1.19.124323)
allowedHTMLLoadExtensions[] =       {"htm","html","php","xml","txt"}; // only allow files and URLs with those extensions to be loaded via htmlLoad command (since Arma 3 v1.27.126715)

// EVENT SCRIPTS - see http://community.bistudio.com/wiki/ArmA:_Server_Side_Scripting
onUserConnected     = "";    // command to run when a player connects
onUserDisconnected  = "";    // command to run when a player disconnects
doubleIdDetected    = "";    // command to run if a player has the same ID as another player in the server
onUnsignedData      = "kick (_this select 0)";    // command to run if a player has unsigned files
onHackedData        = "kick (_this select 0)";    // command to run if a player has tampered files

// HEADLESS CLIENT
headlessClients[]  = {"127.0.0.1"};    // list of IP addresses allowed to connect using headless clients; example: {"127.0.0.1", "192.168.1.100"};
localClient[]      = {"127.0.0.1"};    // list of IP addresses to which are granted unlimited bandwidth; example: {"127.0.0.1", "192.168.1.100"};
```