### PR TITLE
ISSUE-41: only permanent members (external list) are loaded during mission start

### DIFF
--- a/Save/fn_saveFunctions.sqf
+++ b/Save/fn_saveFunctions.sqf
@@ -175,7 +175,9 @@ fn_setData = {
 
 	if (_varName in specialVarLoads) then {
 		call {
-		    if(_varName == 'membersPool') exitWith {{membersPool pushBackUnique _x;} forEach _varValue;};
+		    if(_varName == 'membersPool' AND (['AS_param_onlyPermanentMembers',1] call BIS_fnc_getParamValue) == 0) exitWith {
+		        {membersPool pushBackUnique _x;} forEach _varValue;
+		    };
 			if(_varName == 'campaign_playerList') exitWith {server setVariable ["campaign_playerList",_varValue,true]};
 			if(_varName == 'cuentaCA') exitWith {cuentaCA = _varValue max 2700};
 			if(_varName == 'flag_chopForest') then {

--- a/description.ext
+++ b/description.ext
@@ -330,6 +330,12 @@ class Params {
             typeName = "BOOL";
             force = 1;
     };
+    class AS_param_onlyPermanentMembers {
+        title = "Only permanent members are eligible for commandership at start";
+            values[] = {0,1};
+            texts[] = {"Off","On"};
+            default = 1;
+    };
     #include "aceSettings.hpp"
 };
 


### PR DESCRIPTION
Whether only permanent members (external list) are added to commanders pool (controlled by `AS_param_onlyPermanentMembers` mission parameter)
Fixes #41 