### PR TITLE
NO-REF: Allows external members list have comments. 

### DIFF
--- a/orgPlayers/mList.sqf
+++ b/orgPlayers/mList.sqf
@@ -61,17 +61,19 @@ _mList = [
 
 diag_log format ["isFilePatchingEnabled: %1", isFilePatchingEnabled];
 if(isFilePatchingEnabled) then {
-    _memberList = loadFile (externalConfigFolder + "\memberlist.txt");
+    private _memberList = loadFile (externalConfigFolder + "\memberlist.txt");
     if ( _memberList != "" ) then
 	{
 	    //Members list is in form of CRLF separated playerIds
 	    _mList = _memberList splitString toString [13,10];
 	    diag_log format ["DEBUG: External content from %1",externalConfigFolder + "\memberlist.txt"];
-	    {diag_log format ["DEBUG: members list> %1", _x];} forEach _mList;
 	};
 };
 
 {
-	membersPool pushBackUnique _x;
+    //comma (,) and whitespace are the delimeters, only the first element is considered the ID
+    private _memberID = (_x splitString ", ") select 0;
+    diag_log format ["DEBUG: +memberID: %1", _memberID];
+    membersPool pushBackUnique _memberID;
 } forEach _mList;
 publicVariable "membersPool";


### PR DESCRIPTION
Comments are delimited from id by comma(,) or whitespace( ). Only first substring before delimiter is considered the ID. The rest is discarded

E.g memberlist.txt has
```
1111222 somePlayer1
1112223,   anotherPlayer
9900110 00000
```
resulting IDs are `1111222, 1112223, 9900110`