### PR TITLE
ACE detection revised

### DIFF
--- a/AntistasiOfficial.Altis/Functions/fn_detectACE.sqf
+++ b/AntistasiOfficial.Altis/Functions/fn_detectACE.sqf
@@ -1,18 +1,17 @@
-activeACE = false;
+activeACE = !isNil "ace_common_fnc_isModLoaded";
 activeACEhearing = false;
 activeACEMedical = false;
-if !(isNil "ace_common_settingFeedbackIcons") then {
-	activeACE = true;
+if (activeACE) then {
 	unlockedItems = unlockedItems + ["ACE_EarPlugs","ACE_RangeCard","ACE_Clacker","ACE_M26_Clacker","ACE_DeadManSwitch","ACE_DefusalKit","ACE_MapTools","ACE_Flashlight_MX991","ACE_Sandbag_empty","ACE_wirecutter","ACE_RangeTable_82mm","ACE_SpareBarrel","ACE_EntrenchingTool","ACE_Cellphone","ACE_ConcertinaWireCoil","ACE_CableTie","ACE_SpottingScope","ACE_Tripod","ACE_Chemlight_HiWhite","ACE_Chemlight_HiRed"];
 	unlockedBackpacks pushBackUnique "ACE_TacticalLadder_Pack";
 	unlockedWeapons pushBackUnique "ACE_VMH3";
 	unlockedMagazines = unlockedMagazines + ["ACE_HandFlare_White","ACE_HandFlare_Red"];
 	genItems = genItems + ["ACE_Kestrel4500","ACE_ATragMX"];
 
-	if (isClass (configFile >> "CfgSounds" >> "ACE_EarRinging_Weak")) then {
+	if ("ACE_Hearing" call ace_common_fnc_isModLoaded) then {
 		activeACEhearing = true;
 	};
-	if (isClass (ConfigFile >> "CfgSounds" >> "ACE_heartbeat_fast_3")) then {
+	if ("ACE_Medical" call ace_common_fnc_isModLoaded) then {
 		activeACEMedical = true;
 
 		if (ace_medical_level == 1) then //ACE Basic medical system


### PR DESCRIPTION
ACE detection revised.
The approach is based on the fact of presence of `ace_common_fnc_isModLoaded` variable (actually function). The rest of modules are checked the standard ACE way (via that function)
[Example of how it's done in ACE](https://github.com/acemod/ACE3/blob/5d610cf14854078886976177a3d3c38d2b67a8e0/addons/dogtags/XEH_postInit.sqf#L11) (call is wrapped into CBA macro)

was tested on ACE ver. 3.11.0.26