### PR TITLE
Player data load on login

### DIFF
--- a/AntistasiOfficial.Altis/Save/fn_loadGame.sqf
+++ b/AntistasiOfficial.Altis/Save/fn_loadGame.sqf
@@ -10,14 +10,6 @@ petros allowdamage false;
 flag_playerList = true;
 publicVariable "flag_playerList";
 
-
-//player
-{
-	[_x] call AS_fnc_loadPlayer;
-} forEach (allPlayers - entities "HeadlessClient_F");
-
-
-
 //game
 ["enableMemAcc"] call fn_loadData;
 ["enableOldFT"] call fn_loadData;

--- a/AntistasiOfficial.Altis/description.ext
+++ b/AntistasiOfficial.Altis/description.ext
@@ -1,8 +1,9 @@
+#include "script_component.hpp"
 #include "defines.hpp"
 #include "dialogs.hpp"
 
 author="Barbolani";
-OnLoadName = "Antistasi - modified 1.7.17G";
+OnLoadName = QUOTE(Antistasi - modified ANTISTASI_VERSION);
 OnLoadMission = "Be a Resistance Leader - Be a Hero";
 //loadScreen = "pic.paa";
 

--- a/AntistasiOfficial.Altis/initPlayerLocal.sqf
+++ b/AntistasiOfficial.Altis/initPlayerLocal.sqf
@@ -154,7 +154,7 @@ if (_isJip) then {
 				if (_nearestMarker in mrkAAF) then {
 					_x addAction [localize "STR_ACT_TAKEFLAG", {[[_this select 0, _this select 1],"mrkWIN"] call BIS_fnc_MP;},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"];
 				} else {
-					_x addAction [localize "STR_ACT_RECRUITUNIT", {nul=[] execVM "Dialogs\unit_recruit.sqf";;},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"];
+					_x addAction [localize "STR_ACT_RECRUITUNIT", {nul=[] execVM "Dialogs\unit_recruit.sqf";},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"];
 					_x addAction [localize "STR_ACT_BUYVEHICLE", {createDialog "vehicle_option";},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"];
 					_x addAction [localize "STR_ACT_PERSGARAGE", {[true] spawn garage},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"];
 				};
@@ -182,10 +182,9 @@ if (_isJip) then {
 
 	if ((player == Slowhand) AND (isNil "placementDone") AND (isMultiplayer)) then {
 		[] execVM "UI\startMenu.sqf";
-	} else {
-		[player]remoteExec ["AS_fnc_loadPlayer",2];
-		//[true] execVM "Dialogs\firstLoad.sqf";
 	};
+    //Called from unscheduled environment to load data at once
+    [player] remoteExecCall ["AS_fnc_loadPlayer",2];
 
 	diag_log "Antistasi MP Client. JIP client finished";
 } else {
@@ -213,7 +212,6 @@ if (_isJip) then {
 waitUntil {scriptDone _title};
 
 statistics = [] execVM "statistics.sqf";
-
 
 // Add respawn in SP if ACE is active
 if !(isMultiplayer) then {

--- a/AntistasiOfficial.Altis/initVar.sqf
+++ b/AntistasiOfficial.Altis/initVar.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 private ["_allVehicles","_vehicle"];
 diag_log "InitVar.sqf: start";
 //Antistasi var settings
@@ -6,7 +7,7 @@ diag_log "InitVar.sqf: start";
 //You do not have enough balls to make any modification and after making a Bug report because something is wrong. You don't wanna be there. Believe me.
 //Not commented lines cannot be changed.
 //Don't touch them.
-antistasiVersion = "v 1.7.17G -- modded";
+antistasiVersion = format["v %1 -- modded", QUOTE(ANTISTASI_VERSION)];
 
 servidoresOficiales = ["Antistasi Official: Main","Antistasi Official: Hardcore", "Antistasi Official: USA"];//this is for author's fine tune the official servers. If I get you including your server in this variable, I will create a special variable for your server. Understand?
 

--- a/AntistasiOfficial.Altis/mission.sqm
+++ b/AntistasiOfficial.Altis/mission.sqm
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 version=53;
 class EditorData
 {
@@ -125,7 +126,7 @@ class Mission
 {
 	class Intel
 	{
-		briefingName="[SP/CO] - Antistasi Altis Blufor 1.7.17G ";
+		briefingName=QUOTE([SP/CO] - Antistasi Altis Blufor ANTISTASI_VERSION);
 		overviewText="Build FIA Army from scratch and defeat the AAF and CSAT forces in a whole map Dynamic Mission.";
 		resistanceWest=0;
 		resistanceEast=1;

--- a/AntistasiOfficial.Altis/script_component.hpp
+++ b/AntistasiOfficial.Altis/script_component.hpp
@@ -1,3 +1,5 @@
+#define ANTISTASI_VERSION 1.7.17G
+
 #define PREFIX ANTISTASI
 #define DEBUG_MODE_NORMAL
 #include "\x\cba\addons\main\script_macros_mission.hpp"


### PR DESCRIPTION
Players' data is loaded from single place (initPlayerLocal.sqf) and is executed in unscheduled environment to prevent any race conditions. Supposedly should fix wrong players load-out on restart.
Fixes #59

Also puts version string to single place (AntistasiOfficial.Altis/script_component.hpp)