### PR TITLE
Tolya1 remove instant repair and rearm

### DIFF
--- a/AntistasiOfficial.Altis/Stringtable.xml
+++ b/AntistasiOfficial.Altis/Stringtable.xml
@@ -29,7 +29,7 @@
 				<Original>&lt;img size='1.75' image='\A3\ui_f\data\GUI\cfg\CommunicationMenu\attack_ca.paa' /&gt; Mission Request</Original>
 			</Key>
 			<Key ID="STR_ACT_HEALREPAIR">
-				<Original>&lt;img size='1.75' image='\A3\ui_f\data\IGUI\RscTitles\MPProgress\respawn_ca.paa' /&gt; Heal, Repair and Rearm</Original>
+				<Original>&lt;img size='1.75' image='\A3\ui_f\data\IGUI\RscTitles\MPProgress\respawn_ca.paa' /&gt; Heal all nearby units</Original>
 			</Key>
 			<Key ID="STR_ACT_USEMED">
 				<Original>&lt;img size='1.2' image='\A3\ui_f\data\IGUI\Cfg\Actions\heal_ca.paa' /&gt; Use Medical Supplies</Original>

--- a/AntistasiOfficial.Altis/healandrepair.sqf
+++ b/AntistasiOfficial.Altis/healandrepair.sqf
@@ -17,9 +17,9 @@ _posHQ = getMarkerPos guer_respawn;
 {
 	if (_x distance _posHQ < 100 AND {alive _x}) then {
 		 reportedVehs = reportedVehs - [_x];
-		_x setDamage 0;
+		//_x setDamage 0;
 		//_x setFuel 0.01;  no refuel anymore
-		[_x,1] remoteExec ["setVehicleAmmo",_x];
+		//[_x,1] remoteExec ["setVehicleAmmo",_x];
 	};
 } forEach vehicles;
 

--- a/AntistasiOfficial.Altis/healandrepair.sqf
+++ b/AntistasiOfficial.Altis/healandrepair.sqf
@@ -25,4 +25,4 @@ _posHQ = getMarkerPos guer_respawn;
 
 publicVariable "reportedVehs";
 
-hint "All nearby units and vehicles have been healed or repaired. Near vehicles have been rearmed at full load, plates have been switched.";
+hint "All nearby units have been healed and nearby vehicles have been removed from the reported list.


### PR DESCRIPTION
Hey,
This is a proposition to disallow instant repair/rearm of all vehicles. If you think this is a good idea to try in the next version, the changes here should do it.

This is not tested. I will try to run this when I get home. Also, sorry for the three separate commits, I did it only from the github web interface for the first time.