### PR TITLE
NATOresupplyTweak

### DIFF
--- a/AntistasiOfficial.Altis/Municion/NATOCrate.sqf
+++ b/AntistasiOfficial.Altis/Municion/NATOCrate.sqf
@@ -29,6 +29,8 @@ clearBackpackCargoGlobal _crate;
 				{_crate additemcargoGlobal 		[_x							,	20	];}	//Shells: Smoke and Flares Green and Red
 							foreach bluGLsmoke
 						};
+			_crate addWeaponCargoGlobal 		[selectrandom bluGL			,	1	];
+			_crate addMagazineCargoGlobal 		[selectrandom bluRifleAmmo	,	5	];
 
 			//										Medical
 			if !(activeACEMedical) then{
@@ -48,9 +50,9 @@ clearBackpackCargoGlobal _crate;
 
 			//										From Tier 1
 			if(BE_currentStage > 0) then {
-						_crate addWeaponCargoGlobal 		[selectrandom bluGL			,	5	];
-						_crate addMagazineCargoGlobal 		[selectrandom bluRifleAmmo	,	40	];
-						_crate addItemCargoGlobal			[bluScopes			select 0,	5	];
+						_crate addWeaponCargoGlobal 		[selectrandom bluGL			,	4	];
+						_crate addMagazineCargoGlobal 		[selectrandom bluRifleAmmo	,	35	];
+						_crate addItemCargoGlobal			[bluScopes			select 0,	4	];
 						//_crate addItemCargoGlobal			[bluSuppressor		select 0,	5	];  still missing in templates
 
 // Additional equipment depending on ArmyLevel
@@ -68,7 +70,6 @@ clearBackpackCargoGlobal _crate;
 			_crate addWeaponCargoGlobal 		[bluLMG		 		select 0,	5	]; // LMG
 			_crate addItemCargoGlobal			[bluScopes			select 1,	5	];
 			_crate addMagazineCargoGlobal 		[bluLMGAmmo 		select 0,	40	];
-			_crate addMagazineCargoGlobal 		[blu40mm 			select 0,	40	];
 			_crate addMagazineCargoGlobal 		[selectrandom bluRifleAmmo	,	50	]; // Extra ammo bonus
 	}
 	else {

--- a/AntistasiOfficial.Altis/Municion/NATOCrate.sqf
+++ b/AntistasiOfficial.Altis/Municion/NATOCrate.sqf
@@ -5,164 +5,107 @@ private ["_crate","_NATOSupp","_weapons", "_lmgs", "_lmgAmmo", "_smAmmo", "_int"
 _crate = _this select 0;
 _NATOSupp = _this select 1;
 
-_weapons = bluRifle + bluSNPR + bluLMG + bluSmallWpn;
-_lmgs = [bluLMG select 1];
-_lmgs pushBack (bluLMG select 2);
-
-_lmgAmmo = [bluLMGAmmo select 0];
-_lmgAmmo pushBack (bluLMGAmmo select 1);
-
-_smAmmo = [bluSmallAmmo select 0];
-_smAmmo pushBack (bluSmallAmmo select 1);
-
 clearMagazineCargoGlobal _crate;
 clearWeaponCargoGlobal _crate;
 clearItemCargoGlobal _crate;
 clearBackpackCargoGlobal _crate;
 
 //add jnl load action
-_crate call jn_fnc_logistics_addAction;
+	_crate call jn_fnc_logistics_addAction;
 
-// sniper rifle
-_crate addWeaponCargoGlobal [bluSNPR select 2, 1];
-_crate addMagazineCargoGlobal [(getArray (configFile / "CfgWeapons" / (bluSNPR select 2) / "magazines") select 0), (3+(floor random 4))];
+//Standard Equipment (good for 5 people)
+			//										Weapon
+			_crate addWeaponCargoGlobal 		[bluSmallWpn 		select 0,	5	];
+			_crate addMagazineCargoGlobal 		[bluSmallAmmo 		select 0,	25	];
+			_crate addWeaponCargoGlobal 		[bluSmallWpn 		select 1,	5	];
+			_crate addMagazineCargoGlobal 		[bluSmallAmmo 		select 1,	25	];
+			_crate addWeaponCargoGlobal 		[bluAT		 		select 0,	5	];	//AT tube
+			if(!activeAFRF) then{
+			_crate addWeaponCargoGlobal 		[bluATMissile		select 0,	5	];	//when no RHS or ACE it need ammo
+			};
+			_crate addItemCargoGlobal			["SmokeShellRed"			,	25	];
+			_crate addItemCargoGlobal			["SmokeShellGreen"			,	25	];
+			_crate addItemCargoGlobal			[bluAttachments 	select 0,	5	];	//flashlight
+				{_crate additemcargoGlobal 		[_x							,	20	];}	//Shells: Smoke and Flares Green and Red
+							foreach bluGLsmoke
+						};
 
-// sniper rifle
-_crate addWeaponCargoGlobal [selectRandom bluSNPR,1];
-_crate addMagazineCargoGlobal [selectRandom bluSNPRAmmo, (3+(floor random 4))];
+			//										Medical
+			if !(activeACEMedical) then{
+				_crate addItemCargoGlobal		["FirstAidKit"				,	25	];
+				_crate addItemCargoGlobal 		["Medikit"					,	1	];
+				}
+				else{
+				_crate addItemCargoGlobal		["ACE_epinephrine"			,	10	];
+				_crate addItemCargoGlobal		["ACE_morphine"				,	25	];
+				_crate addItemCargoGlobal		["ACE_fieldDressing"		,	25	];
+				_crate addItemCargoGlobal		["ACE_bloodIV"				,	40	];
+				};
+			//										Generic
 
-// shotgun/smg/sidearm
-_crate addWeaponCargoGlobal [selectRandom bluSmallWpn, 1];
-_crate addMagazineCargoGlobal [selectRandom bluSmallAmmo, (4+(floor random 2))];
+			_crate addItemCargoGlobal 			["ToolKit"					,	1	];
+			_crate addItemCargoGlobal 			["MineDetector"				,	1	];
 
-// AT launcher
-_crate addWeaponCargoGlobal [bluAT select 1, 2];
-if (replaceFIA) then {
-	_crate addMagazineCargoGlobal [selectRandom bluATMissile, (3+(floor random 3))];
-};
+			//										From Tier 1
+			if(BE_currentStage > 0) then {
+						_crate addWeaponCargoGlobal 		[selectrandom bluGL			,	5	];
+						_crate addMagazineCargoGlobal 		[selectrandom bluRifleAmmo	,	40	];
+						_crate addItemCargoGlobal			[bluScopes			select 0,	5	];
+						//_crate addItemCargoGlobal			[bluSuppressor		select 0,	5	];  still missing in templates
 
-// accessory
-_crate addItemCargoGlobal [selectRandom (bluAttachments + bluScopes), 1];
-
-if (_NATOSupp > 80) then {
-	// sniper rifle
-	_crate addWeaponCargoGlobal [bluSNPR select 0, 1];
-	_crate addItemCargoGlobal [bluScopes select 0, 1];
-	_crate addMagazineCargoGlobal [bluSNPRAmmo select 0, (1+(floor random 4))];
-	_crate addMagazineCargoGlobal [bluSNPRAmmo select 1, (1+(floor random 2))];
-
-	// rifle with 40mm
-	_crate addWeaponCargoGlobal [selectRandom bluGL, 3];
-	_crate addMagazineCargoGlobal [selectRandom bluRifleAmmo, 3*(3+(floor random 4))];
-	_crate addMagazineCargoGlobal [blu40mm select 0, 3*(2+(floor random 4))];
-	_crate addMagazineCargoGlobal [selectRandom blu40mm, 3*(1+(floor random 3))];
-
-	// LMG
-	_crate addWeaponCargoGlobal [bluLMG select 0, 1];
-	_crate addMagazineCargoGlobal [selectRandom _lmgAmmo, (2+(floor random 3))];
-
-	// LMG
-	_crate addWeaponCargoGlobal [selectRandom _lmgs, 1];
-	_crate addMagazineCargoGlobal [bluLMGAmmo select 2, (2+(floor random 3))];
-
-	// shotgun/SMG
-	_crate addWeaponCargoGlobal [bluSmallWpn select 0, 1];
-	_crate addMagazineCargoGlobal [selectRandom _smAmmo, (4+(floor random 6))];
-
-	// sidearm
-	_crate addWeaponCargoGlobal [bluSmallWpn select 1, 1];
-	_crate addMagazineCargoGlobal [bluSmallAmmo select 2, (6+(floor random 3))];
-
-	// AT launcher
-	_crate addWeaponCargoGlobal [bluAT select 0, 1];
-	_crate addMagazineCargoGlobal [selectRandom bluATMissile, (3+(floor random 3))];
-
-	// AA launcher
-	_crate addWeaponCargoGlobal [bluAA select 0, 1];
-	_crate addMagazineCargoGlobal [selectRandom bluAAMissile, (3+(floor random 3))];
-
-	// scopes
-	_crate addItemCargoGlobal [selectRandom bluScopes, 2];
-
-	// attachment
-	_crate addItemCargoGlobal [selectRandom bluAttachments, 4];
-}
-else {
-	if (_NATOSupp > 60) then {
-		// sniper rifle
-		_crate addWeaponCargoGlobal [bluSNPR select 0, 1];
-		_crate addMagazineCargoGlobal [bluSNPRAmmo select 1, (2+(floor random 4))];
-
-		// rifle with 40mm
-		_crate addWeaponCargoGlobal [selectRandom bluGL, 2];
-		_crate addMagazineCargoGlobal [selectRandom bluRifleAmmo, 2*(3+(floor random 4))];
-		_crate addMagazineCargoGlobal [blu40mm select 0, 2*(2+(floor random 4))];
-		_crate addMagazineCargoGlobal [selectRandom blu40mm, 2*(1+(floor random 3))];
-
-		// LMG
-		_crate addWeaponCargoGlobal [bluLMG select 0, 1];
-		_crate addMagazineCargoGlobal [selectRandom _lmgAmmo, (2+(floor random 3))];
-
-		// shotgun/SMG
-		_crate addWeaponCargoGlobal [bluSmallWpn select 0, 1];
-		_crate addMagazineCargoGlobal [bluSmallAmmo select 1, (4+(floor random 2))];
-
-		// AT launcher
-		_crate addWeaponCargoGlobal [bluAT select 0, 1];
-		_crate addMagazineCargoGlobal [selectRandom bluATMissile, (3+(floor random 3))];
-
-		// scopes
-		_crate addItemCargoGlobal [selectRandom bluScopes, 1];
-
-		// attachment
-		_crate addItemCargoGlobal [selectRandom bluAttachments, 3];
+// Additional equipment depending on ArmyLevel
+	if (BE_currentStage == 3) then {
+			_crate addItemCargoGlobal 			[bluHelmet			select 2,	5	]; //Helmet T3
+			_crate addWeaponCargoGlobal 		[bluSNPR 			select 1,	5	]; //Sniper
+			_crate addItemCargoGlobal			[bluScopes			select 2,	5	];
+			_crate addMagazineCargoGlobal 		[bluSNPRAmmo 		select 1,	50	];
+			_crate addWeaponCargoGlobal 		[bluAA 				select 0,	5	]; //AA
+			_crate addMagazineCargoGlobal 		[bluAAMissile 		select 0,	10	];
+			_crate addWeaponCargoGlobal 		[bluAT		 		select 2,	2	]; //AT Guided
+			_crate addMagazineCargoGlobal 		[bluATMissile 		select 2,	4	];
+			_crate addWeaponCargoGlobal 		[bluAT		 		select 1,	5	]; //AT Non guided + rockets
+			_crate addMagazineCargoGlobal 		[bluATMissile 		select 1,	10	];
+			_crate addWeaponCargoGlobal 		[bluLMG		 		select 0,	5	]; // LMG
+			_crate addItemCargoGlobal			[bluScopes			select 1,	5	];
+			_crate addMagazineCargoGlobal 		[bluLMGAmmo 		select 0,	40	];
+			_crate addMagazineCargoGlobal 		[blu40mm 			select 0,	40	];
+			_crate addMagazineCargoGlobal 		[selectrandom bluRifleAmmo	,	50	]; // Extra ammo bonus
 	}
 	else {
-		if (_NATOSupp > 30) then {
-			// sniper rifle
-			_crate addWeaponCargoGlobal [bluSNPR select 1, 1];
-			_crate addItemCargoGlobal [bluScopes select 0, 1];
-			_crate addMagazineCargoGlobal [bluSNPRAmmo select 2, (4+(floor random 3))];
-
-			// rifle with 40mm
-			_crate addWeaponCargoGlobal [selectRandom bluGL, 1];
-			_crate addMagazineCargoGlobal [selectRandom bluRifleAmmo, 1*(3+(floor random 4))];
-			_crate addMagazineCargoGlobal [selectRandom blu40mm, 1*(2+(floor random 3))];
-
-			// LMG
-			_crate addWeaponCargoGlobal [selectRandom _lmgs, 1];
-			_crate addMagazineCargoGlobal [bluLMGAmmo select 2, (2+(floor random 3))];
-
-			// sidearm
-			_crate addWeaponCargoGlobal [bluSmallWpn select 1, 1];
-			_crate addMagazineCargoGlobal [bluSmallAmmo select 2, (6+(floor random 3))];
-
-			// AA launcher
-			_crate addWeaponCargoGlobal [bluAA select 0, 1];
-			_crate addMagazineCargoGlobal [selectRandom bluAAMissile, (3+(floor random 3))];
-
-			// attachment
-			_crate addItemCargoGlobal [selectRandom bluAttachments, 2];
+	if (BE_currentStage == 2) then {
+			_crate addItemCargoGlobal 			[bluHelmet			select 1,	5	]; //Helmet T2
+			_crate addWeaponCargoGlobal 		[bluSNPR 			select 0,	5	]; //Sniper
+			_crate addItemCargoGlobal			[bluScopes			select 2,	5	];
+			_crate addMagazineCargoGlobal 		[bluSNPRAmmo 		select 0,	50	];
+			_crate addWeaponCargoGlobal 		[bluAA 				select 0,	3	]; //AA
+			_crate addMagazineCargoGlobal 		[bluAAMissile 		select 0,	6	];
+			_crate addWeaponCargoGlobal 		[bluAT		 		select 2,	1	]; //AT Guided
+			_crate addMagazineCargoGlobal 		[bluATMissile 		select 2,	2	];
+			_crate addWeaponCargoGlobal 		[bluAT		 		select 1,	2	]; //AT Non guided + rockets
+			_crate addMagazineCargoGlobal 		[bluATMissile 		select 1,	6	];
+			_crate addWeaponCargoGlobal 		[bluLMG		 		select 0,	5	]; // LMG
+			_crate addItemCargoGlobal			[bluScopes			select 1,	5	];
+			_crate addMagazineCargoGlobal 		[bluLMGAmmo 		select 0,	20	];
+			_crate addMagazineCargoGlobal 		[selectrandom bluRifleAmmo	,	25	]; // Extra ammo
+	}
+	else {
+		if (BE_currentStage == 1) then {
+			_crate addItemCargoGlobal 			[bluHelmet			select 0,	5	]; //Helmet T1
+			_crate addWeaponCargoGlobal 		[bluSNPR 			select 0,	2	]; //Sniper
+			_crate addMagazineCargoGlobal 		[bluSNPRAmmo 		select 0,	25	];
+			_crate addWeaponCargoGlobal 		[bluAA 				select 0,	1	]; //AA
+			_crate addMagazineCargoGlobal 		[bluAAMissile 		select 0,	2	];
+			_crate addWeaponCargoGlobal 		[bluAT		 		select 2,	1	]; //AT Guided
+			_crate addMagazineCargoGlobal 		[bluATMissile 		select 2,	2	];
+			_crate addWeaponCargoGlobal 		[bluAT		 		select 1,	2	]; //AT Non guided + rockets
+			_crate addMagazineCargoGlobal 		[bluATMissile 		select 1,	2	];
+			_crate addWeaponCargoGlobal 		[bluLMG		 		select 0,	2	]; // LMG
+			_crate addItemCargoGlobal			[bluScopes			select 1,	2	];
+			_crate addMagazineCargoGlobal 		[bluLMGAmmo 		select 0,	8	];
 		};
 	};
 };
 
-if (_NATOSupp > 60) then {
-	// rifle
-	_crate addWeaponCargoGlobal [selectRandom bluRifle, 3];
-	_crate addMagazineCargoGlobal [selectRandom bluRifleAmmo, 3*(3+(floor random 4))];
-
-	// vest
-	_crate addItemCargoGlobal [bluVest select 0, 2];
-}
-else {
-	// rifle
-	_crate addWeaponCargoGlobal [selectRandom bluRifle, 2];
-	_crate addMagazineCargoGlobal [selectRandom bluRifleAmmo, 2*(3+(floor random 4))];
-
-	// vest
-	_crate addItemCargoGlobal [bluVest select 1, 2];
-};
 
 if (activeAFRF) then {
 	_crate addItemCargoGlobal ["Laserdesignator",1];
@@ -183,6 +126,7 @@ if (activeACE) then {
 	_crate addMagazineCargoGlobal ["ACE_HuntIR_M203", 3];
 	_crate addItemCargoGlobal ["ACE_HuntIR_monitor", 1];
 
+// This should be added only from the tier you get the sniper rifle.
 	if (_NATOSupp > 60) then {
 		_crate addItemCargoGlobal ["ACE_Vector", 5];
 		_crate addItemCargoGlobal ["ACE_microDAGR", 5];
@@ -196,6 +140,7 @@ if (activeACE) then {
 		_crate addItemCargoGlobal ["ACE_Kestrel4500", 3];
 	};
 };
+
 
 if (_NATOSupp < 50) then {
 	_crate addBackpackCargoGlobal ["B_Static_Designator_01_weapon_F",1];

--- a/AntistasiOfficial.Altis/Templates/BLUE_NATO.sqf
+++ b/AntistasiOfficial.Altis/Templates/BLUE_NATO.sqf
@@ -1,178 +1,174 @@
-bluHeliTrans = 		["B_Heli_Light_01_F","B_Heli_Transport_01_camo_F","B_Heli_Transport_03_F"];
-bluHeliTS = 		["B_Heli_Light_01_F"];
-bluHeliDis = 		["B_Heli_Transport_01_camo_F"];
-bluHeliRope = 		["B_Heli_Transport_03_F"];
-bluHeliArmed = 		["B_Heli_Light_01_armed_F"];
-bluHeliGunship = 	["B_Heli_Attack_01_F"];
-bluCASFW = 			["B_Plane_CAS_01_F"];
+//Blu NATO vehicles
+	bluHeliTrans = 		["B_Heli_Light_01_F","B_Heli_Transport_01_camo_F","B_Heli_Transport_03_F"];
+	bluHeliTS = 		["B_Heli_Light_01_F"];
+	bluHeliDis = 		["B_Heli_Transport_01_camo_F"];
+	bluHeliRope = 		["B_Heli_Transport_03_F"];
+	bluHeliArmed = 		["B_Heli_Light_01_armed_F"];
+	bluHeliGunship = 	["B_Heli_Attack_01_F"];
+	bluCASFW = 			["B_Plane_CAS_01_F"];
 
-bluAS = 			[""];
-bluC130 = 			[""];
+	bluAS = 			[""];
+	bluC130 = 			[""];
 
-bluUAV = 			["B_UAV_02_F"];
+	bluUAV = 			["B_UAV_02_F"];
 
-planesNATO = bluHeliTrans + bluHeliArmed + bluHeliGunship + bluCASFW;
-planesNATOTrans = bluHeliTrans;
-
-
-bluMBT = 		["B_MBT_01_cannon_F","B_MBT_01_TUSK_F"];
-bluAPC = 		["B_APC_Wheeled_01_cannon_F"];
-bluIFV = 		["B_APC_Tracked_01_rcws_F"];
-bluIFVAA = 		["B_APC_Tracked_01_AA_F"];
-bluArty = 		["B_MBT_01_arty_F"]; bluArtyAmmoHE = "32Rnd_155mm_Mo_shells"; bluArtyAmmoLaser = "2Rnd_155mm_Mo_LG"; bluArtyAmmoSmoke = "2Rnd_155mm_Mo_LG";
-bluMLRS = 		["B_MBT_01_mlrs_F"];
-bluMRAP =		["B_MRAP_01_F"];
-bluMRAPHMG =	["B_MRAP_01_hmg_F"];
-bluTruckTP = 	["B_Truck_01_covered_F"];
-bluTruckMed = 	["B_Truck_01_medical_F"];
-bluTruckFuel = 	["B_Truck_01_fuel_F"];
-
-vehNATO = bluMBT + bluAPC + bluIFV + bluIFVAA + bluArty + bluMLRS + bluMRAP + bluMRAPHMG + bluTruckTP + bluTruckMed + bluTruckFuel;
+	planesNATO = bluHeliTrans + bluHeliArmed + bluHeliGunship + bluCASFW;
+	planesNATOTrans = bluHeliTrans;
 
 
-bluStatAA = 	["B_static_AA_F"];
-bluStatAT = 	["B_static_AT_F"];
-bluStatHMG = 	["B_HMG_01_high_F"];
-bluStatMortar = ["B_G_Mortar_01_F"];
+	bluMBT = 		["B_MBT_01_cannon_F","B_MBT_01_TUSK_F"];
+	bluAPC = 		["B_APC_Wheeled_01_cannon_F"];
+	bluIFV = 		["B_APC_Tracked_01_rcws_F"];
+	bluIFVAA = 		["B_APC_Tracked_01_AA_F"];
+	bluArty = 		["B_MBT_01_arty_F"]; bluArtyAmmoHE = "32Rnd_155mm_Mo_shells"; bluArtyAmmoLaser = "2Rnd_155mm_Mo_LG"; bluArtyAmmoSmoke = "2Rnd_155mm_Mo_LG";
+	bluMLRS = 		["B_MBT_01_mlrs_F"];
+	bluMRAP =		["B_MRAP_01_F"];
+	bluMRAPHMG =	["B_MRAP_01_hmg_F"];
+	bluTruckTP = 	["B_Truck_01_covered_F"];
+	bluTruckMed = 	["B_Truck_01_medical_F"];
+	bluTruckFuel = 	["B_Truck_01_fuel_F"];
+
+	vehNATO = bluMBT + bluAPC + bluIFV + bluIFVAA + bluArty + bluMLRS + bluMRAP + bluMRAPHMG + bluTruckTP + bluTruckMed + bluTruckFuel;
 
 
-bluPilot = 	"B_Pilot_F";
-bluCrew = 	"B_crew_F";
-bluGunner = "B_support_MG_F";
+	bluStatAA = 	["B_static_AA_F"];
+	bluStatAT = 	["B_static_AT_F"];
+	bluStatHMG = 	["B_HMG_01_high_F"];
+	bluStatMortar = ["B_G_Mortar_01_F"];
 
-bluMRAPHMGgroup = 	["B_recon_LAT_F","B_Recon_Sharpshooter_F"];
-bluMRAPgroup = 		["B_recon_medic_F","B_recon_F","B_recon_JTAC_F"];
+//Blu NATO units
+	bluCfgInf = (configfile >> "CfgGroups" >> "West" >> "BLU_F" >> "Infantry");
 
-bluAirCav = 	["B_recon_TL_F","B_recon_LAT_F","B_Recon_Sharpshooter_F","B_recon_medic_F","B_recon_F","B_recon_JTAC_F"];
+	bluPilot = 	"B_Pilot_F";
+	bluCrew = 	"B_crew_F";
+	bluGunner = "B_support_MG_F";
 
+	bluMRAPHMGgroup = 	["B_recon_LAT_F","B_Recon_Sharpshooter_F"];
+	bluMRAPgroup = 		["B_recon_medic_F","B_recon_F","B_recon_JTAC_F"];
 
-bluSquad = 			["BUS_InfSquad"];
-bluSquadWeapons = 	["BUS_InfSquad_Weapons"];
-bluTeam = 			["BUS_InfTeam"];
-bluATTeam = 		["BUS_InfTeam_AT"];
-
-bluIR = 	"acc_pointer_IR";
-
-bluFlag = 	"Flag_NATO_F";
-
-bluCfgInf = (configfile >> "CfgGroups" >> "West" >> "BLU_F" >> "Infantry");
+	bluAirCav = 	["B_recon_TL_F","B_recon_LAT_F","B_Recon_Sharpshooter_F","B_recon_medic_F","B_recon_F","B_recon_JTAC_F"];
 
 
-bluRifle = [
-	"arifle_MX_F",
-	"arifle_MX_SW_F"
-];
+	bluSquad = 			["BUS_InfSquad"];
+	bluSquadWeapons = 	["BUS_InfSquad_Weapons"];
+	bluTeam = 			["BUS_InfTeam"];
+	bluATTeam = 		["BUS_InfTeam_AT"];
 
-bluGL = [
-	"arifle_MX_GL_F"
-];
+	bluIR = 	"acc_pointer_IR";
 
-bluSNPR = [
-	"srifle_LRR_F",
-	"srifle_DMR_02_F",
-	"srifle_EBR_F",
-	"srifle_DMR_03_F"
-];
+	bluFlag = 	"Flag_NATO_F";
 
-bluLMG = [
-	"MMG_02_sand_F",
-	"arifle_MX_SW_F"
-];
+//bluEquipment
+	bluSmallWpn = 	[					// select reference
+		"hgun_Pistol_heavy_01_F",      	// 0 Pistol
+		"SMG_02_F"     					// 1 SecondarySMG or Shotgun short
+	];
 
-bluSmallWpn = [
-	"SMG_01_F",
-	"hgun_ACPC2_F"
-];
+	bluSmallAmmo = [					// select reference
+		"11Rnd_45ACP_Mag",  			// 0 Pistol ammo
+		"30Rnd_9x21_Mag_SMG_02"			// 1 SecondarySMG ammo
+	];
 
-bluRifleAmmo = [
-	"30Rnd_65x39_Caseless_mag",
-	"30Rnd_65x39_caseless_mag_Tracer"
-];
+	bluRifle = 	[ 						// select random
+		"arifle_MXC_Black_F",			// 0 Rifle
+		"arifle_MX_GL_Black_F"			// 0 GL rifle
+	];
 
-bluSNPRAmmo = [
-	"7Rnd_408_Mag",
-	"10Rnd_338_Mag",
-	"20Rnd_762x51_Mag"
-];
+	bluRifleAmmo = [						// select random (this might require a tweak if blurifle have rifle with different ammo, try to keep the same)
+		"30Rnd_65x39_caseless_mag",
+		"30Rnd_65x39_caseless_mag_Tracer"
+	];
 
-bluLMGAmmo = [
-	"130Rnd_338_Mag",
-	"100Rnd_65x39_Caseless_mag",
-	"100Rnd_65x39_caseless_mag_Tracer"
-];
+	bluGL = [
+		blurifle select 1
+	];
 
-bluSmallAmmo = [
-	"30Rnd_45ACP_Mag_SMG_01",
-	"30Rnd_45ACP_Mag_SMG_01_tracer_green",
-	"11Rnd_45ACP_Mag"
-];
+	bluGLsmoke = [							// theese should be selected all, i don't know how to
+		"UGL_FlareGreen_F",
+		"UGL_FlareRed_F",
+		"1Rnd_SmokeRed_Grenade_shell",
+		"1Rnd_SmokeGreen_Grenade_shell"
+	];
 
-bluAmmo = [
-	"30Rnd_65x39_Caseless_mag",
-	"30Rnd_65x39_caseless_mag_Tracer",
-	"100Rnd_65x39_Caseless_mag",
-	"100Rnd_65x39_caseless_mag_Tracer",
-	"20Rnd_762x51_Mag",
-	"7Rnd_408_Mag",
-	"30Rnd_45ACP_Mag_SMG_01",
-	"30Rnd_45ACP_Mag_SMG_01_tracer_green",
-	"11Rnd_45ACP_Mag",
-	"20Rnd_762x51_Mag",
-	"10Rnd_338_Mag",
-	"130Rnd_338_Mag"
-];
+	bluSNPR = 	[
+		"srifle_EBR_F",			//7.62mm
+		"srifle_LRR_F"			//big gun, only for higher tier
+	];
 
-blu40mm = [
-	"1Rnd_HE_Grenade_shell",
-	"1Rnd_Smoke_Grenade_shell"
-];
+	bluSNPRAmmo = [
+		"20Rnd_762x51_Mag",
+		"7Rnd_408_Mag"
+	];
 
-bluGrenade = [
-	"HandGrenade"
-];
+	bluLMG = 	[
+		"arifle_MX_SW_F",				//Tier 1
+		"LMG_Zafir_F"					//Tier 2
+	];
 
-bluAT = [
-	"launch_B_Titan_short_F",
-	"launch_NLAW_F"
-];
+	bluLMGAmmo = [
+		"100Rnd_65x39_caseless_mag",	//Tier 1
+		"150Rnd_762x54_Box"				//Tier 2
+	];
 
-bluAA = [
-	"launch_B_Titan_F"
-];
+	bluGrenade = [
+		"HandGrenade",		//
+		"MiniGrenade"
+	];
 
-bluVest = [
-	"V_PlateCarrierSpec_mtp"
-];
+	bluAT = [
+		"launch_NLAW_F",			//Tier 1
+		"launch_NLAW_F",			//Tier 2
+		"launch_B_Titan_short_F"	//Tier 3
+	];
 
-bluScopes = [
-	"optic_Nightstalker",
-	"optic_Holosight",
-	"optic_Hamr",
-	"optic_ERCO_snd_F"
-];
+	bluATMissile = [
+		"NLAW_F",			// Tier 1 single use
+		"NLAW_F",			// Tier 2
+		"Titan_AT"			// Tier 3
+	];
 
-bluAttachments = [
-	"muzzle_snds_338_sand",
-	"bipod_01_F_snd",
-	"muzzle_snds_H_khk_F",
-	"muzzle_snds_B_snd_F"
-];
+	bluAA = [
+		"launch_B_Titan_F"		//Higher tier
+	];
 
-bluATMissile = [
-	"NLAW_F",
-	"Titan_AT",
-	"Titan_AP"
-];
+	bluAAMissile = [
+		"Titan_AA"			//Higher tier
+	];
 
-bluAAMissile = [
-	"Titan_AA"
-];
+	bluVest = [				//Need to check stats
+		"rhsusf_spc_light",		//0 - Tier 1
+		"rhsusf_spc_crewman"	//1 - Tier 2
+	];							//2 - Tier 3
 
-bluItems = bluVest + bluScopes + bluAttachments;
+	bluScopes = [					// Preferibly only PIP compatible = more realisitc
+		"optic_Hamr",				// 0 Normal
+		"optic_MRCO",				// 1 LMG
+		"optic_DMS"					// 2 Sniper
+	];
+
+	bluAttachments = [
+		"acc_flashlight", 			//anpeq with laser + flashlight
+		"bipod_01_F_snd",			//Bipod
+		"muzzle_snds_L",			//Higer tier only
+		"acc_flashlight_pistol",	//pistol flashlight
+		"optic_MRD"					//pistol optic
+	];
+
+	bluSuppressor = [
+	"muzzle_snds_acp",
+	"muzzle_snds_L"
+	];
+
+	bluHelmet = [
+	"H_HelmetB_light_black",		// Tier 1
+	"H_HelmetB_black",				// Tier 2
+	"H_HelmetSpecB_blk"				// Tier 3
+	];
+
 
 genGL = genGL + bluGL;
-//genATLaunchers = genATLaunchers + bluAT; // using vanilla launchers right now
-//genAALaunchers = genAALaunchers + bluAA;
+genATLaunchers = genATLaunchers + bluAT;
+genAALaunchers = genAALaunchers + bluAA;
 
 // Colour of this faction's markers
 BLUFOR_marker_colour = "ColorWEST";

--- a/AntistasiOfficial.Altis/Templates/BLUE_USAF.sqf
+++ b/AntistasiOfficial.Altis/Templates/BLUE_USAF.sqf
@@ -1,182 +1,166 @@
-bluHeliTrans = 		["RHS_MELB_MH6M","RHS_UH60M","RHS_CH_47F_light"];
-bluHeliTS = 		["RHS_MELB_MH6M"];
-bluHeliDis = 		["RHS_UH60M"];
-bluHeliRope = 		["RHS_CH_47F_light"];
-bluHeliArmed = 		["RHS_MELB_AH6M_H","RHS_MELB_AH6M_M"];
-bluHeliGunship = 	["RHS_AH64D_AA","RHS_AH64D_GS","RHS_AH64D"];
-bluCASFW = 			["RHS_A10"];
+//Blu USAF vehicles
+	bluHeliTrans = 		["RHS_MELB_MH6M","RHS_UH60M","RHS_CH_47F_light"];
+	bluHeliTS = 		["RHS_MELB_MH6M"];
+	bluHeliDis = 		["RHS_UH60M"];
+	bluHeliRope = 		["RHS_CH_47F_light"];
+	bluHeliArmed = 		["RHS_MELB_AH6M_H","RHS_MELB_AH6M_M"];
+	bluHeliGunship = 	["RHS_AH64D_AA","RHS_AH64D_GS","RHS_AH64D"];
+	bluCASFW = 			["RHS_A10"];
 
-bluAS = 			["rhsusf_f22"];
-bluC130 = 			["RHS_C130J"];
+	bluAS = 			["rhsusf_f22"];
+	bluC130 = 			["RHS_C130J"];
 
-bluUAV = 			["B_UAV_02_F"];
+	bluUAV = 			["B_UAV_02_F"];
 
-planesNATO = bluHeliTrans + bluHeliArmed + bluHeliGunship + bluCASFW;
-planesNATOTrans = bluHeliTrans;
-
-
-bluMBT = 		["rhsusf_m1a2sep1wd_usarmy","rhsusf_m1a2sep1tuskiwd_usarmy"];
-bluAPC = 		["RHS_M2A3_wd","RHS_M2A3_BUSKI_wd"];
-bluIFV = 		["rhsusf_m113_usarmy_M240","rhsusf_m113_usarmy_supply"];
-bluIFVAA = 		["RHS_M6_wd"];
-bluArty = 		["RHS_M119_W"]; bluArtyAmmoHE = "RHS_mag_m1_he_12"; bluArtyAmmoLaser = nil; bluArtyAmmoSmoke = "rhs_mag_m60a2_smoke_4";
-bluMLRS = 		["B_MBT_01_mlrs_F"];
-bluMRAP = 		["rhsusf_m1025_W","rhsusf_m998_w_4dr_halftop","rhsusf_m998_w_4dr_fulltop"];
-bluMRAPHMG = 	["rhsusf_m1025_W_m2","rhsusf_rg33_m2_W"];
-bluTruckTP = 	["rhsusf_M1083A1P2_B_M2_wd_fmtv_usarmy"];
-bluTruckMed = 	["rhsusf_M1083A1P2_B_M2_d_Medical_fmtv_usarmy"];
-bluTruckFuel = 	["rhsusf_M978A4_BKIT_usarmy_wd"];
-
-vehNATO = bluMBT + bluAPC + bluIFV + bluIFVAA + bluArty + bluMLRS + bluMRAP + bluMRAPHMG + bluTruckTP + bluTruckMed + bluTruckFuel;
+	planesNATO = bluHeliTrans + bluHeliArmed + bluHeliGunship + bluCASFW;
+	planesNATOTrans = bluHeliTrans;
 
 
-bluStatAA = 	["RHS_Stinger_AA_pod_WD"];
-bluStatAT = 	["RHS_TOW_TriPod_WD"];
-bluStatHMG = 	["RHS_M2StaticMG_WD"];
-bluStatMortar = ["RHS_M252_WD"];
+	bluMBT = 		["rhsusf_m1a2sep1wd_usarmy","rhsusf_m1a2sep1tuskiwd_usarmy"];
+	bluAPC = 		["RHS_M2A3_wd","RHS_M2A3_BUSKI_wd"];
+	bluIFV = 		["rhsusf_m113_usarmy_M240","rhsusf_m113_usarmy_supply"];
+	bluIFVAA = 		["RHS_M6_wd"];
+	bluArty = 		["RHS_M119_W"]; bluArtyAmmoHE = "RHS_mag_m1_he_12"; bluArtyAmmoLaser = nil; bluArtyAmmoSmoke = "rhs_mag_m60a2_smoke_4";
+	bluMLRS = 		["B_MBT_01_mlrs_F"];
+	bluMRAP = 		["rhsusf_m1025_W","rhsusf_m998_w_4dr_halftop","rhsusf_m998_w_4dr_fulltop"];
+	bluMRAPHMG = 	["rhsusf_m1025_W_m2","rhsusf_rg33_m2_W"];
+	bluTruckTP = 	["rhsusf_M1083A1P2_B_M2_wd_fmtv_usarmy"];
+	bluTruckMed = 	["rhsusf_M1083A1P2_B_M2_d_Medical_fmtv_usarmy"];
+	bluTruckFuel = 	["rhsusf_M978A4_BKIT_usarmy_wd"];
+
+	vehNATO = bluMBT + bluAPC + bluIFV + bluIFVAA + bluArty + bluMLRS + bluMRAP + bluMRAPHMG + bluTruckTP + bluTruckMed + bluTruckFuel;
 
 
-bluPilot = 	"rhsusf_army_ocp_helipilot";
-bluCrew = 	"rhsusf_usmc_marpat_wd_combatcrewman";
-bluGunner = "rhsusf_usmc_marpat_wd_rifleman_light";
+	bluStatAA = 	["RHS_Stinger_AA_pod_WD"];
+	bluStatAT = 	["RHS_TOW_TriPod_WD"];
+	bluStatHMG = 	["RHS_M2StaticMG_WD"];
+	bluStatMortar = ["RHS_M252_WD"];
 
-bluMRAPHMGgroup = 	["rhsusf_usmc_fr_marpat_wd_riflemanat","rhsusf_usmc_fr_marpat_wd_rifleman","rhsusf_usmc_fr_marpat_wd_autorifleman_m249"];
-bluMRAPgroup = 		["rhsusf_usmc_fr_marpat_wd_teamleader","rhsusf_usmc_fr_marpat_wd_marksman","rhsusf_usmc_fr_marpat_wd_autorifleman"];
+//Blu USAF units
+	bluCfgInf = (configfile >> "CfgGroups" >> "West" >> "rhs_faction_usmc_wd" >> "rhs_group_nato_usmc_wd_infantry");
 
+	bluPilot = 	"rhsusf_army_ocp_helipilot";
+	bluCrew = 	"rhsusf_usmc_marpat_wd_combatcrewman";
+	bluGunner = "rhsusf_usmc_marpat_wd_rifleman_light";
 
-bluAirCav = 	["rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_marksman","rhsusf_usmc_marpat_wd_autorifleman","rhsusf_usmc_marpat_wd_riflemanat","rhsusf_usmc_marpat_wd_rifleman","rhsusf_usmc_marpat_wd_autorifleman_m249"];
-
-bluSquad = 			["rhs_group_nato_usmc_wd_infantry_squad"]; // 12
-bluSquadWeapons = 	["rhs_group_nato_usmc_wd_infantry_weaponsquad"]; // 7
-bluTeam = 			["rhs_group_nato_usmc_wd_infantry_team"]; // 4
-bluATTeam = 		["rhs_group_nato_usmc_wd_infantry_team_heavy_AT"]; // 4
-
-bluIR = 	"rhsusf_acc_anpeq15";
-
-bluFlag = 	"Flag_NATO_F";
-
-bluCfgInf = (configfile >> "CfgGroups" >> "West" >> "rhs_faction_usmc_wd" >> "rhs_group_nato_usmc_wd_infantry");
+	bluMRAPHMGgroup = 	["rhsusf_usmc_fr_marpat_wd_riflemanat","rhsusf_usmc_fr_marpat_wd_rifleman","rhsusf_usmc_fr_marpat_wd_autorifleman_m249"];
+	bluMRAPgroup = 		["rhsusf_usmc_fr_marpat_wd_teamleader","rhsusf_usmc_fr_marpat_wd_marksman","rhsusf_usmc_fr_marpat_wd_autorifleman"];
 
 
-bluRifle = 	[
-	"rhs_weap_m16a4_carryhandle",
-	"rhs_weap_m4a1_carryhandle",
-	"rhs_weap_m4a1_grip"
-];
+	bluAirCav = 	["rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_marksman","rhsusf_usmc_marpat_wd_autorifleman","rhsusf_usmc_marpat_wd_riflemanat","rhsusf_usmc_marpat_wd_rifleman","rhsusf_usmc_marpat_wd_autorifleman_m249"];
 
-bluGL = [
-	"rhs_weap_m16a4_carryhandle_M203",
-	"rhs_weap_m4a1_carryhandle_m203S",
-	"rhs_weap_m4a1_m203s"
-];
+	bluSquad = 			["rhs_group_nato_usmc_wd_infantry_squad"]; // 12
+	bluSquadWeapons = 	["rhs_group_nato_usmc_wd_infantry_weaponsquad"]; // 7
+	bluTeam = 			["rhs_group_nato_usmc_wd_infantry_team"]; // 4
+	bluATTeam = 		["rhs_group_nato_usmc_wd_infantry_team_heavy_AT"]; // 4
 
-bluSNPR = 	[
-	"rhs_weap_m107_leu",
-	"rhs_weap_m40_wd_usmc",
-	"rhs_weap_sr25"
-];
+	bluIR = 	"rhsusf_acc_anpeq15";
 
-bluLMG = 	[
-	"rhs_weap_m240G",
-	"rhs_weap_m249_pip_L_para",
-	"rhs_weap_m249_pip_S_vfg"
-];
+	bluFlag = 	"Flag_NATO_F";
 
-bluSmallWpn = 	[
-	"rhs_weap_M590_5RD",
-	"rhsusf_weap_m1911a1"
-];
+//bluEquipment
+	bluSmallWpn = 	[					// select reference
+		"rhsusf_weap_MP7A2",      		// 0 SMG
+		"rhs_weap_M590_5RD"     		// 1 SecondarySMG or Shotgun short
+	];
 
-bluRifleAmmo = [
-	"rhs_mag_30Rnd_556x45_Mk318_Stanag",
-	"rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red"
-];
+	bluSmallAmmo = [					// select reference
+		"rhsusf_mag_40Rnd_46x30_FMJ",  	// 0 SMG ammo
+		"rhsusf_5Rnd_Slug"				// 1 SecondarySMG ammo
+	];
 
-bluSNPRAmmo = [
-	"rhsusf_mag_10Rnd_STD_50BMG_M33",
-	"rhsusf_mag_10Rnd_STD_50BMG_mk211",
-	"rhsusf_10Rnd_762x51_m118_special_Mag",
-	"rhsusf_20Rnd_762x51_m118_special_Mag",
-	"20Rnd_762x51_Mag"
-];
+	bluRifle = 	[ 						// select random
+		"rhs_weap_hk416d10_m320",
+		"rhs_weap_m4_m320",
+		"rhs_weap_mk18_m320"
+	];
 
-bluLMGAmmo = [
-	"rhsusf_50Rnd_762x51",
-	"rhsusf_100Rnd_762x51_m62_tracer",
-	"rhs_200rnd_556x45_M_SAW"
-];
+	bluRifleAmmo = [					// select random (this might require a tweak if blurifle have rifle with different ammo, try to keep the same)
+		"rhs_mag_30Rnd_556x45_M855_Stanag",
+		"rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red"
+	];
 
-bluSmallAmmo = [
-	"rhsusf_5Rnd_00Buck",
-	"rhsusf_5Rnd_FRAG",
-	"rhsusf_mag_7x45acp_MHP"
-];
+	bluGL = bluRifle;
 
-bluAmmo = [
-	"rhsusf_mag_10Rnd_STD_50BMG_M33",
-	"rhsusf_mag_10Rnd_STD_50BMG_mk211",
-	"rhs_mag_30Rnd_556x45_Mk318_Ball",
-	"rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red",
-	"rhsusf_20Rnd_762x51_m118_special_Mag",
-	"rhsusf_10Rnd_762x51_m118_special_Mag",
-	"rhs_200rnd_556x45_M_SAW",
-	"rhsusf_5Rnd_00Buck",
-	"rhs_mag_smaw_SR",
-	"20Rnd_762x51_Mag",
-	"rhsusf_100Rnd_762x51_m61_ap",
-	"rhsusf_100Rnd_762x51_m62_tracer",
-	"rhsusf_mag_7x45acp_MHP"
-];
+	bluGLsmoke = [							// how can i additemcargoglobal [item,5] for each of them?
+		"rhs_mag_m662_red",
+		"rhs_mag_m661_green",
+		"rhs_mag_m713_Red",
+		"rhs_mag_m715_Green"
+	];
 
-blu40mm = [
-	"rhs_mag_M433_HEDP",
-	"1Rnd_HE_Grenade_shell",
-	"SmokeShell",
-	"SmokeShellGreen",
-	"rhs_mag_m576"
-];
+	bluSNPR = 	[
+		"rhs_weap_m24sws",		//Tier 1
+		"rhs_weap_XM2010"		//Tier 2
+	];
 
-bluGrenade = [
-	"HandGrenade",
-	"MiniGrenade"
-];
+	bluSNPRAmmo = [
+		"rhsusf_5Rnd_762x51_m118_special_Mag",	//Tier1
+		"rhsusf_5Rnd_300winmag_xm2010"			//Tier2
+	];
 
-bluAT = [
-	"rhs_weap_smaw_optic",
-	"rhs_weap_M136_hedp"
-];
+	bluLMG = 	[
+		"rhs_weap_m249_pip_S_vfg",	//Tier1
+		"rhs_weap_m249_pip_S_vfg"	//Tier2
+	];
 
-bluAA = [
-	"rhs_weap_fim92"
-];
+	bluLMGAmmo = [
+		"rhsusf_100Rnd_556x45_soft_pouch",	//Tier1
+		"rhsusf_100Rnd_556x45_soft_pouch"	//Tier 2
+	];
 
-bluVest = [
-	"rhsusf_spc_rifleman",
-	"rhsusf_spc_crewman"
-];
+	bluGrenade = [
 
-bluScopes = [
-	"rhsusf_acc_LEUPOLDMK4",
-	"rhsusf_acc_ACOG3_USMC",
-	"rhsusf_acc_compm4"
-];
+		//missing
+	];
 
-bluAttachments = [
-	"rhsusf_acc_harris_bipod",
-	"rhsusf_acc_sr25S",
-	"rhsusf_acc_anpeq15A",
-	"rhsusf_acc_nt4_black"
-];
+	bluAT = [
+		"rhs_weap_M136_hedp",	//Tier 1 Standard, single use
+		"rhs_weap_smaw_optic",	//Tier 2
+		"rhs_weap_fgm148"		//Tier 3
 
-bluATMissile = [
-	"rhs_mag_smaw_HEAA"
-];
+	];
 
-bluAAMissile = [
-	"rhs_fim92_mag"
-];
+	bluATMissile = [
+		""							//Tier 1
+		"rhs_mag_smaw_HEAA"			//Only high tier
+		"rhs_fgm148_magazine_AT"	//Locking
+	];
 
-bluItems = bluVest + bluScopes + bluAttachments;
+	bluAA = [
+		"rhs_weap_fim92"		//Higher tier
+	];
+
+	bluAAMissile = [
+		"rhs_fim92_mag"		//Higher tier
+	];
+
+	bluVest = [				//Need to check stats
+		"rhsusf_spc_rifleman",
+		"rhsusf_spc_crewman"
+	];
+
+	bluScopes = [					// Preferibly only PIP compatible = more realisitc
+		"rhsusf_acc_SpecterDR_3d",	//Rifle scope
+		"rhsusf_acc_ACOG_MDO",		//LMG scope
+		"rhsusf_acc_LEUPOLDMK4_2_d"	//Snipe scope
+	];
+
+	bluAttachments = [
+		"rhsusf_acc_anpeq15_light", //anpeq with laser + flashlight
+		"rhsusf_acc_nt4_black"		//Higer tier only
+	];
+
+	bluSuppressor = [
+	"" //missing
+	];
+
+	bluHelmet = [
+	"rhsusf_opscore_bk_pelt"					// Tier 1
+	"rhsusf_ach_bare_des_headset"				// Tier 2
+	"rhsusf_mich_bare_norotos_semi_headset"		// Tier 3
+	];
+
 
 genGL = genGL + bluGL;
 genATLaunchers = genATLaunchers + bluAT;

--- a/AntistasiOfficial.Altis/Templates/BLUE_USAF.sqf
+++ b/AntistasiOfficial.Altis/Templates/BLUE_USAF.sqf
@@ -122,9 +122,9 @@
 	];
 
 	bluATMissile = [
-		""							//Tier 1
-		"rhs_mag_smaw_HEAA"			//Only high tier
-		"rhs_fgm148_magazine_AT"	//Locking
+		//"",							//Tier 1
+		"rhs_mag_smaw_HEAA",			//Only high tier
+		"rhs_fgm148_magazine_AT"		//Locking
 	];
 
 	bluAA = [
@@ -156,8 +156,8 @@
 	];
 
 	bluHelmet = [
-	"rhsusf_opscore_bk_pelt"					// Tier 1
-	"rhsusf_ach_bare_des_headset"				// Tier 2
+	"rhsusf_opscore_bk_pelt",					// Tier 1
+	"rhsusf_ach_bare_des_headset",				// Tier 2
 	"rhsusf_mich_bare_norotos_semi_headset"		// Tier 3
 	];
 


### PR DESCRIPTION
Merged in a proper branch.
I'd suggest to copy the code to poseidon/sublime to properly see the column stacking

This tweak aim to make the Ammodrop something you want into battle instead of sitting at HQ. 
Goods are balanced for 5 people and they vary from weapons to medical supplies and some utilities

The quality and quantity is now determinated by ArmyLevel and no longer from NATO support value.

Always guaranteed: medical, smoke, toolkit, minedetector, 1 uav, smgs, basic AT, flashlights, gl with smoke and flares,

Missing and WiP: 
- grenades (maybe adapting with RHS variants)
- support for other templates (now only NATO and USAF are integrated)