### PR TITLE
UPS RANDOM patrol behaviour

### DIFF
--- a/AntistasiOfficial.Altis/Scripts/UPSMON.sqf
+++ b/AntistasiOfficial.Altis/Scripts/UPSMON.sqf
@@ -253,7 +253,8 @@ if (_initpos!="ORIGINAL") then
 	
 	if (_initpos=="RANDOM") then
 	{
-		while {_try<20} do 
+	    _grp call UPSMON_DeleteWP;
+		while {_try<20} do
 		{
 			if (_grptype == "Isboat" || _grptype == "Isdiver") then 
 			{
@@ -284,7 +285,7 @@ if (_initpos!="ORIGINAL") then
 				_targetpos = _currPos findEmptyPosition [0, 50];
 				sleep .05;						
 				if (count _targetpos == 0) then {_targetpos = _currpos};
-				_x setpos _targetpos;	
+				_x setPos _targetpos;
 			}
 			else
 			{
@@ -292,7 +293,7 @@ if (_initpos!="ORIGINAL") then
 				If (_grptype != "Isboat") then {_targetpos = _currPos findEmptyPosition [10,50];};
 				sleep .05;						
 				if (count _targetpos == 0) then {_targetpos = _currpos};
-				_x setPos _targetpos;		
+				_x setPos _targetpos;
 			};
 		} foreach units _npc; 
 	} 


### PR DESCRIPTION
Group created with `BIS_Fnc_spawnGroup` has default 1st waypoint. If it's sent to UPSMON with RANDOM param, that makes group subordinates move to that initial wp after teleportation. As the result we have leader separated from the group.