### PR TITLE
add editorconfig file

### DIFF
--- a/AntistasiOfficial.Altis/.editorconfig
+++ b/AntistasiOfficial.Altis/.editorconfig
@@ -1,0 +1,10 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tabs
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/AntistasiOfficial.Altis/Stringtable.xml
+++ b/AntistasiOfficial.Altis/Stringtable.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><Project name="Antistasi">
+<?xml version="1.0" encoding="UTF-8"?>
+<Project name="Antistasi">
 	<Package name="MissionNames">
 		<Container name="MissionNames_0">
 			<Key ID="STR_MISSION_NAME_SQM">


### PR DESCRIPTION
Editor config ensure a consistent code styling in project, just add the editorconfig plugin of your IDE and you should be set.

This will avoid these non-consistent use of tabs/spaces and odd indents : 
<img width="775" alt="capture d ecran 2018-04-21 a 16 31 21" src="https://user-images.githubusercontent.com/3863527/39085601-51259db4-4585-11e8-866d-abf4919aa1b0.png">
(dots represent spaces and lines represent tabs)

See http://editorconfig.org/ for more info.

Feel free to request config for specific filename extensions.