### PR TITLE
Destroyed antennas (#311)

### DIFF
--- a/AntistasiOfficial.Altis/mrkWIN.sqf
+++ b/AntistasiOfficial.Altis/mrkWIN.sqf
@@ -59,7 +59,7 @@ _bandera addAction [localize "str_act_mapInfo",
 // [[_bandera,"garage"],"AS_fnc_addActionMP"] call BIS_fnc_MP; Stef 27/10 disabled old garage
 
 _antenna = [antenas,_posicion] call BIS_fnc_nearestPosition;
-if (getPos _antenna distance _posicion < 100) then {
+if (count antenas != 0 AND getPos _antenna distance _posicion < 100) then {
 	[_bandera,"jam"] remoteExec ["AS_fnc_addActionMP"];
 };
 

--- a/AntistasiOfficial.Altis/mrkWIN.sqf
+++ b/AntistasiOfficial.Altis/mrkWIN.sqf
@@ -59,7 +59,7 @@ _bandera addAction [localize "str_act_mapInfo",
 // [[_bandera,"garage"],"AS_fnc_addActionMP"] call BIS_fnc_MP; Stef 27/10 disabled old garage
 
 _antenna = [antenas,_posicion] call BIS_fnc_nearestPosition;
-if (count antenas != 0 AND getPos _antenna distance _posicion < 100) then {
+if ((count antenas != 0) AND (getPos _antenna distance _posicion < 100)) then {
 	[_bandera,"jam"] remoteExec ["AS_fnc_addActionMP"];
 };
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman


### PR DESCRIPTION
Fixed mrkWIN.sqf aborting of no antenna in antenas.
If none found or none active the JAM action will not be added
Simple fix.

(Sorry for that _config.yml file, played abit around with the configs of github and gthub was like, yeah create an instant commit for this)
Fix #311 