### PR TITLE
Enhancement: Drop loaded ammo when surrender

### DIFF
--- a/AntistasiOfficial.Altis/AI/surrenderAction.sqf
+++ b/AntistasiOfficial.Altis/AI/surrenderAction.sqf
@@ -1,4 +1,4 @@
-private ["_unit","_coste","_armas","_municion","_caja","_items"];
+private ["_unit","_coste","_armas","_municion","_caja","_items","_loaded"];
 
 _unit = _this select 0;
 
@@ -39,7 +39,10 @@ clearItemCargoGlobal _caja;
 clearBackpackCargoGlobal _caja;
 _armas = weapons _unit;
 {_caja addWeaponCargoGlobal [[_x] call BIS_fnc_baseWeapon,1]} forEach _armas;
-_municion = magazines _unit;
+for "_x" from 0 to (count _armas -1) do {
+	_loaded pushBack (weaponsItems _unit select _x select 4 select 0);
+};
+_municion = magazines _unit + _loaded;
 {_caja addMagazineCargoGlobal [_x,1]} forEach _municion;
 _items = assignedItems _unit + items _unit + primaryWeaponItems _unit;
 {_caja addItemCargoGlobal [_x,1]} forEach _items;


### PR DESCRIPTION
Fix for #243. Surrendering enemy drop magazine/ammo currently loaded to weapon(s).

Ammo currently loaded to weapons are not counted by magazines _unit, and needs to be specifically checked with weaponsItems _unit.
select _x select 4 select 0 returns the classname (select 0) of the magazine (select 4) currently in weapon number _x.

The numbering sequence is main weapon>launcher (if any)>pistol (if any), so that typically the launcher is weapon number 1.

Directly calling weaponsItems _unit select 1 select 4 select 0 when the unit have no secondary weapons seems to return nothing or an error. Calling the function on a unit with no weapons may also cause error.
Further testing and optimization required.