### PR TITLE
The missing enemy roadblocks have been restored

### DIFF
--- a/AntistasiOfficial.Altis/CREATE/createRoadblock2.sqf
+++ b/AntistasiOfficial.Altis/CREATE/createRoadblock2.sqf
@@ -1,10 +1,14 @@
 /*
-Testing advanced roadblock spawning script. Sparker.
+Testing advanced roadblock spawning script.
+By Sparker
 */
 if (!isServer and hasInterface) exitWith {};
 
-params ["_marker"];
+params ["_marker", "_rbData"];
 private ["_allVehicles","_allGroups","_allSoldiers","_markerPos","_size","_distance","_roads","_connectedRoads","_bunker","_static","_group","_unit","_groupType","_tempGroup","_dog","_normalPos"];
+
+//Check the composition data
+if(isNil "_rbData") exitWith {diag_log format ["createRoadblock2.sqf: Error: no _rbData found for %1", _marker];};
 
 _allVehicles = [];
 _allGroups = [];
@@ -16,10 +20,6 @@ _size = [_marker] call sizeMarker;
 //Delete trees
 private _no = nearestTerrainObjects [_markerPos, ["TREE", "SMALL TREE", "BUSH"], 20, false, true];
 {hideObjectGlobal _x;} forEach _no;
-
-//Get the composition data
-private _rbData = roadblocksEnemy getVariable [_marker, nil];
-if(isNil "_rbData") exitWith {diag_log format ["createRoadblock2.sqf: Error: no _rbData found for %1", _marker];};
 
 private _objects = [_markerPos, _rbData select 1, _rbData select 0] call BIS_fnc_ObjectsMapper;
 

--- a/AntistasiOfficial.Altis/Stringtable.xml
+++ b/AntistasiOfficial.Altis/Stringtable.xml
@@ -3,13 +3,13 @@
 	<Package name="MissionNames">
 		<Container name="MissionNames_0">
 			<Key ID="STR_MISSION_NAME_SQM">
-				<Original>[SP/CO]- Antistasi 1.8.0.7 Altis Blufor</Original>
+				<Original>[SP/CO]- Antistasi 1.8.0.9 Altis Blufor</Original>
 			</Key>
 			<Key ID="STR_MISSION_NAME_INITVAR_SQF">
-				<Original>v 1.8.0.7</Original>
+				<Original>v 1.8.0.9</Original>
 			</Key>
 			<Key ID="STR_MISSION_NAME_EXT">
-				<Original>Antistasi 1.8.0.7</Original>
+				<Original>Antistasi 1.8.0.9</Original>
 			</Key>
 		</Container>
 	</Package>

--- a/AntistasiOfficial.Altis/distancias3.sqf
+++ b/AntistasiOfficial.Altis/distancias3.sqf
@@ -53,8 +53,7 @@ while {true} do {
 						if (_marker in ciudades) exitWith {[_marker] remoteExec ["createCIV", call AS_fnc_getNextWorker]; [_marker] remoteExec ["createCity", call AS_fnc_getNextWorker]};
 						if (_marker in power) exitWith {[_marker] remoteExec ["createPower", call AS_fnc_getNextWorker]};
 						if (_marker in bases) exitWith {[_marker] remoteExec ["createBase", call AS_fnc_getNextWorker]};
-						//if (_marker in controles) exitWith {[_marker] remoteExec ["createRoadblock", call AS_fnc_getNextWorker]};
-						if (_marker in controles) exitWith {[_marker] remoteExec ["createRoadblock2", call AS_fnc_getNextWorker]};
+						if (_marker in controles) exitWith {[_marker, roadblocksEnemy getVariable [_marker, nil]] remoteExec ["createRoadblock2", call AS_fnc_getNextWorker]}; // Server must take the composition of the roadblock from its roadblockEnemy logic object and sends it to the worker
 						if (_marker in aeropuertos) exitWith {[_marker] remoteExec ["createAirbase", call AS_fnc_getNextWorker]};
 						if ((_marker in recursos) OR (_marker in fabricas)) exitWith {[_marker] remoteExec ["createResources", call AS_fnc_getNextWorker]};
 						if ((_marker in puestos) OR (_marker in puertos)) exitWith {[_marker] remoteExec ["createOutpost", call AS_fnc_getNextWorker]};


### PR DESCRIPTION
### !!! Make sure you also correct this in your modified distancias3.sqf !!!
They couldn't spawn on headless clients because the roadblock composition is stored in server's **roadblocksEnemy** logic object's variables which are **local to the server**. Solution is simple: on remote-calling the CREATE/roadblock2.sqf also pass it the roadblock composition as argument, like this: [_marker, roadblocksEnemy getVariable [_marker, nil]] remoteExec ["createRoadblock2", call AS_fnc_getNextWorker]